### PR TITLE
Add 'take' to Data.Conduit.Binary.

### DIFF
--- a/conduit/Data/Conduit/Binary.hs
+++ b/conduit/Data/Conduit/Binary.hs
@@ -16,6 +16,7 @@ module Data.Conduit.Binary
 
 import Prelude hiding (head, take)
 import qualified Data.ByteString as S
+import qualified Data.ByteString.Lazy as L
 import Data.Conduit
 import qualified Data.Conduit.List as CL
 import Control.Exception (assert)
@@ -204,6 +205,6 @@ head = Sink $ return $ SinkData
     , sinkClose = return Nothing
     }
 
-take :: Resource m => Int -> Sink S.ByteString m S.ByteString
-take n = S.concat `liftM` (isolate n =$ CL.consume)
+take :: Resource m => Int -> Sink S.ByteString m L.ByteString
+take n = L.fromChunks `liftM` (isolate n =$ CL.consume)
 

--- a/conduit/test/main.hs
+++ b/conduit/test/main.hs
@@ -349,7 +349,7 @@ main = hspecX $ do
       -- Taking nothing should result in an empty Bytestring
       it "nothing" $ do
         (a, b) <- runResourceT $ go 0 ["abc", "defg"]
-        a              @?= S.empty
+        a              @?= L.empty
         L.fromChunks b @?= "abcdefg"
 
       it "normal" $ do


### PR DESCRIPTION
This branch adds a _take_ function to Data.Conduit.Binary that extracts the given number of bytes from the stream.
