### PR TITLE
network-conduit: add ApplicationM type to exports

### DIFF
--- a/network-conduit/Data/Conduit/Network.hs
+++ b/network-conduit/Data/Conduit/Network.hs
@@ -6,6 +6,7 @@ module Data.Conduit.Network
     , sinkSocket
       -- * Simple TCP server/client interface.
     , Application
+    , ApplicationM
       -- ** Server
     , ServerSettings (..)
     , runTCPServer


### PR DESCRIPTION
This can really simplify function declarations
