### PR TITLE
tests: increase wait time when TCP server initializes

### DIFF
--- a/network-conduit/test/main.hs
+++ b/network-conduit/test/main.hs
@@ -6,7 +6,7 @@ import Control.Monad (replicateM_)
 main :: IO ()
 main = do
     _ <- forkIO $ runTCPServer (ServerSettings 4000 Nothing) echo
-    threadDelay 1000
+    threadDelay 1000000
     replicateM_ 10000
         $ runTCPClient (ClientSettings 4000 "localhost") doNothing
 


### PR DESCRIPTION
1 millisecond is clearly not enough for a slow machine like my one:
    $ runhaskell Setup.lhs test
    Running 1 test suites...
    Test suite test: RUNNING...
    test: connect: does not exist (Connection refused)
    Test suite test: FAIL
    Test suite logged to: dist/test/network-conduit-0.2.2-test.log
    0 of 1 test suites (0 of 1 test cases) passed.

Increased up to 1 second:
    $ runhaskell Setup.lhs test
    Running 1 test suites...
    Test suite test: RUNNING...
    Test suite test: PASS
    Test suite logged to: dist/test/network-conduit-0.2.2-test.log
    1 of 1 test suites (1 of 1 test cases) passed.

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
