### PR TITLE
Use Void instead of () for the input type of a source.

### DIFF
--- a/conduit/Data/Conduit/Lazy.hs
+++ b/conduit/Data/Conduit/Lazy.hs
@@ -27,4 +27,4 @@ lazyConsume (PipeM msrc _) = liftBaseOp_ unsafeInterleaveIO $ do
     if a
         then msrc >>= lazyConsume
         else return []
-lazyConsume (NeedInput p _) = lazyConsume $ p ()
+lazyConsume (NeedInput _ c) = lazyConsume c

--- a/conduit/Data/Conduit/List.hs
+++ b/conduit/Data/Conduit/List.hs
@@ -333,5 +333,5 @@ zip (PipeM mx closex) (PipeM my closey) = PipeM (liftM2 zip mx my) (closex >> cl
 zip (PipeM mx closex) y@(HaveOutput _ closey _) = PipeM (liftM (\x -> zip x y) mx) (closex >> closey)
 zip x@(HaveOutput _ closex _) (PipeM my closey) = PipeM (liftM (\y -> zip x y) my) (closex >> closey)
 zip (HaveOutput srcx closex x) (HaveOutput srcy closey y) = HaveOutput (zip srcx srcy) (closex >> closey) (x, y)
-zip (NeedInput p _) right = zip (p ()) right
-zip left (NeedInput p _) = zip left (p ())
+zip (NeedInput _ c) right = zip c right
+zip left (NeedInput _ c) = zip left c


### PR DESCRIPTION
Use the close field when a source uses the NeedInput constructor. Also
use the close field when a sink uses the HaveOuput constructor (with
undefined f.e.).
