### PR TITLE
conduit: tell Haddock not to link into Internals module

### DIFF
--- a/conduit/Data/Conduit/Internal.hs
+++ b/conduit/Data/Conduit/Internal.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_HADDOCK not-home #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}


### PR DESCRIPTION
Alternatively we could tell Haddock not to generate docs for the Internals module.
