### PR TITLE
Work around a memory leak in 'sequence'

### DIFF
--- a/conduit/Data/Conduit/Util/Conduit.hs
+++ b/conduit/Data/Conduit/Util/Conduit.hs
@@ -172,8 +172,10 @@ sequenceSink state0 fsink = do
 --
 -- Since 0.3.0
 sequence :: Monad m => Sink input m output -> Conduit input m output
-sequence sink = do
-    x <- hasInput
-    when x $ do
-      sinkToPipe sink >>= yield
-      sequence sink
+sequence sink = self
+  where
+    self = do
+        x <- hasInput
+        when x $ do
+          sinkToPipe sink >>= yield
+          self


### PR DESCRIPTION
The first testcase posted https://github.com/snoyberg/conduit/issues/40 still leaks with the current HEAD, compiled with ghc-7.4.1 -O2. I think the problem is that full-laziness transformation done by GHC transforms the definition of 'sequence' to a leaky form. Putting {-# OPTIONS_GHC -fno-full-laziness #-} at the top of Data.Conduit.Util.Conduit fixes the problem.

Here is a link to a glasgow-haskell-users thread that mentions the issue: http://www.haskell.org/pipermail/glasgow-haskell-users/2011-February/019997.html

I think this should ideally fixed by fixing GHC, but in the above thread Simon Peyton Jones says it's difficult. So I suppose it might be a good idea to explicitly work around it in conduit.

The commit works around the problem by making the top-level definition non-recursive. Other functions might suffer from a similar problem but I have not checked.
