### PR TITLE
Slightly faster Binary.lines

### DIFF
--- a/conduit/Data/Conduit/Binary.hs
+++ b/conduit/Data/Conduit/Binary.hs
@@ -308,5 +308,5 @@ lines = NeedInput (push S.empty) (close S.empty)
                         NeedInput (push rest) (close rest)
     close rest
         | S.null rest = Done Nothing ()
-        | otherwise   = Done (Just rest) ()
+        | otherwise   = HaveOutput (Done Nothing ()) (return ()) rest
 


### PR DESCRIPTION
Slightly faster than using stateConduit (0.50s vs 0.60s before the change in a simple count the lines benchmark [5M lines]), with -O2.

This is similar to a recent blog post in Yesod blog.
