### PR TITLE
Fix doc syntax error, so conduit documentation appears on Hackage

### DIFF
--- a/conduit/Data/Conduit/Internal.hs
+++ b/conduit/Data/Conduit/Internal.hs
@@ -573,10 +573,10 @@ infixl 9 >+>
 -- you have a @Pipe@ with leftovers, you must first call 'injectLeftovers'. For
 -- example:
 --
--- > :load Data.Conduit.List
--- > :set -XNoMonomorphismRestriction
--- > let pipe = peek >>= \x -> fold (Prelude.+) 0 >>= \y -> return (x, y)
--- > runPipe $ sourceList [1..10] >+> injectLeftovers pipe
+-- >>> :load Data.Conduit.List
+-- >>> :set -XNoMonomorphismRestriction
+-- >>> let pipe = peek >>= \x -> fold (Prelude.+) 0 >>= \y -> return (x, y)
+-- >>> runPipe $ sourceList [1..10] >+> injectLeftovers pipe
 -- (Just 1,55)
 --
 -- Since 0.5.0


### PR DESCRIPTION
The documentation for [conduit-1.0.0](http://hackage.haskell.org/package/conduit-1.0.0) didn't show up on Hackage.  Hopefully this will fix it.
