### PR TITLE
Fix test in case of non empty env.

### DIFF
--- a/unix-process-conduit/test/Data/Conduit/Process/UnixSpec.hs
+++ b/unix-process-conduit/test/Data/Conduit/Process/UnixSpec.hs
@@ -81,6 +81,6 @@ spec = describe "unix-process-conduit" $ do
             (Just sink)
             Nothing
         res <- waitForProcess pid
-        lbs <- getLBS
+        lbs <- fmap (filter (L.isPrefixOf "foo=") . L.split 10) getLBS
         res `shouldBe` ExitSuccess
-        lbs `shouldBe` L.fromChunks ["foo=bar\n"]
+        lbs `shouldBe` [L.fromChunks ["foo=bar"]]


### PR DESCRIPTION
In some cases where environment is not empty (e.g. in a sandbox) tests fail with:

1) Data.Conduit.Process.Unix.unix-process-conduit environment is set
expected: "foo=bar\n"
 but got: "LD_PRELOAD=libsandbox.so\nfoo=bar\n"

This patch fixes issue as in filter value we are interested in.
