### PR TITLE
update network examples to compile

### DIFF
--- a/network-conduit/echo-server.hs
+++ b/network-conduit/echo-server.hs
@@ -3,7 +3,7 @@ import Data.Conduit
 import Data.Conduit.Network
 
 main :: IO ()
-main = runTCPServer (ServerSettings 3001 "127.0.0.1") echo
+main = runTCPServer (serverSettings 3001 "127.0.0.1") echo
 
 echo :: Application IO
-echo src sink = src $$ sink
+echo app = (appSource app) $$ (appSink app)


### PR DESCRIPTION
The examples in the network-conduit don't compile with the current version.  I have updated them so they appear to run correctly, so I think I have done the correct changes.
