### PR TITLE
Allow to force port binding with an explicit version of IP

### DIFF
--- a/network-conduit/Data/Conduit/Network/Utils.hs
+++ b/network-conduit/Data/Conduit/Network/Utils.hs
@@ -32,7 +32,11 @@ getSocket host' port' sockettype = do
 --
 -- * @*4@ means @HostIPv4@
 --
+-- * @!4@ means @HostIPv4Only@
+--
 -- * @*6@ means @HostIPv6@
+--
+-- * @!6@ means @HostIPv6Only@
 data HostPreference =
     HostAny
   | HostIPv4
@@ -48,9 +52,9 @@ instance IsString HostPreference where
     {-
     fromString "*" = HostAny
     fromString "*4" = HostIPv4
-    fromString "!4" = HostIPv4
+    fromString "!4" = HostIPv4Only
     fromString "*6" = HostIPv6
-    fromString "!6" = HostIPv6
+    fromString "!6" = HostIPv6Only
     -}
     fromString s'@('*':s) =
         case s of


### PR DESCRIPTION
Without this patch it could be troublesome to check that your socket really gets bound to a port and protocol requested. Imagine asking to bind to IPv4 "127.0.0.1:1024" while this address is already taken by another process on the same computer. If you use HostIPv4 for your HostPreference, you'll end up without an exception, but with IPv6 port 1024 bound, which is counterintuitive (at least for me). To check if you are really bound with v4, you'll have to implement afterBind handler inspecting a socket and throwing exception if something is wrong. 

This patch allows you to tell "bind with IPv4 only and throw an exception if you fail" without an afterBind hack.
