### PR TITLE
Remove an extra backslash

### DIFF
--- a/resourcet/Control/Monad/Trans/Resource/Internal.hs
+++ b/resourcet/Control/Monad/Trans/Resource/Internal.hs
@@ -14,7 +14,7 @@ module Control.Monad.Trans.Resource.Internal(
   , MonadThrow(..)
   , MonadUnsafeIO(..)
   , ReleaseKey(..)
-  , ReleaseMap(..)\
+  , ReleaseMap(..)
   , ResIO
   , ResourceT(..)
   , stateAlloc


### PR DESCRIPTION
This extra backslash prevents me from using cpphs as a preprocessor.
