### PR TITLE
conduit.cabal: add missing test files to tarball

### DIFF
--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -68,6 +68,8 @@ Library
 test-suite test
     hs-source-dirs: test
     main-is: main.hs
+    other-modules: Data.Conduit.Extra.ZipConduitSpec
+                   Data.Conduit.ExtraSpec
     type: exitcode-stdio-1.0
     cpp-options:   -DTEST
     build-depends:   conduit


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
