### PR TITLE
Escape forward-slashes in Data.Conduit.Lift docs.

### DIFF
--- a/conduit/Data/Conduit/Lift.hs
+++ b/conduit/Data/Conduit/Lift.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
--- | Allow monad transformers to be run/eval/exec in a section of conduit
+-- | Allow monad transformers to be run\/eval\/exec in a section of conduit
 -- rather then needing to run across the whole conduit.  The circumvents many
 -- of the problems with breaking the monad transformer laws.  For more
 -- information, see the announcement blog post:


### PR DESCRIPTION
Escape forward-slashes in Data.Conduit.Lift docs.

Perusing the docs on Hackage, I noticed "eval' was italicized - this PR should fix that.
