### PR TITLE
Add a non-throwing version of 'sinkParser'

### DIFF
--- a/conduit-extra/Data/Conduit/Attoparsec.hs
+++ b/conduit-extra/Data/Conduit/Attoparsec.hs
@@ -13,6 +13,7 @@
 module Data.Conduit.Attoparsec
     ( -- * Sink
       sinkParser
+    , sinkParserEither
       -- * Conduit
     , conduitParser
     , conduitParserEither
@@ -115,6 +116,12 @@ instance AttoparsecInput T.Text where
 sinkParser :: (AttoparsecInput a, MonadThrow m) => A.Parser a b -> Consumer a m b
 sinkParser = fmap snd . sinkParserPosErr (Position 1 1)
 
+-- | Same as 'sinkParser', but we return an 'Either' type instead
+-- of raising an exception.
+--
+-- Since x.x.x
+sinkParserEither :: (AttoparsecInput a, Monad m) => A.Parser a b -> Consumer a m (Either ParseError b)
+sinkParserEither = (fmap.fmap) snd . sinkParserPos (Position 1 1)
 
 
 -- | Consume a stream of parsed tokens, returning both the token and

--- a/conduit-extra/test/Data/Conduit/AttoparsecSpec.hs
+++ b/conduit-extra/test/Data/Conduit/AttoparsecSpec.hs
@@ -24,84 +24,119 @@ spec = describe "Data.Conduit.AttoparsecSpec" $ do
                 badCol = 6
                 parser = Data.Attoparsec.Text.endOfInput <|> (Data.Attoparsec.Text.notChar 'b' >> parser)
                 sink = sinkParser parser
+                sink' = sinkParserEither parser
             ea <- runExceptionT $ CL.sourceList input $$ sink
             case ea of
                 Left e ->
                     case fromException e of
                         Just pe -> do
                             errorPosition pe `shouldBe` Position badLine badCol
+            ea' <- CL.sourceList input $$ sink'
+            case ea' of
+                Left pe ->
+                    errorPosition pe `shouldBe` Position badLine badCol
         it "works for bytestring" $ do
             let input = ["aaa\na", "aaa\n\n", "aaa", "aab\n\naaaa"]
                 badLine = 4
                 badCol = 6
                 parser = Data.Attoparsec.ByteString.Char8.endOfInput <|> (Data.Attoparsec.ByteString.Char8.notChar 'b' >> parser)
                 sink = sinkParser parser
+                sink' = sinkParserEither parser
             ea <- runExceptionT $ CL.sourceList input $$ sink
             case ea of
                 Left e ->
                     case fromException e of
                         Just pe -> do
                             errorPosition pe `shouldBe` Position badLine badCol
+            ea' <- CL.sourceList input $$ sink'
+            case ea' of
+                Left pe ->
+                    errorPosition pe `shouldBe` Position badLine badCol
         it "works in last chunk" $ do
             let input = ["aaa\na", "aaa\n\n", "aaa", "aab\n\naaaa"]
                 badLine = 6
                 badCol = 5
                 parser = Data.Attoparsec.Text.char 'c' <|> (Data.Attoparsec.Text.anyChar >> parser)
                 sink = sinkParser parser
+                sink' = sinkParserEither parser
             ea <- runExceptionT $ CL.sourceList input $$ sink
             case ea of
                 Left e ->
                     case fromException e of
                         Just pe -> do
                             errorPosition pe `shouldBe` Position badLine badCol
+            ea' <- CL.sourceList input $$ sink'
+            case ea' of
+                Left pe ->
+                    errorPosition pe `shouldBe` Position badLine badCol
         it "works in last chunk" $ do
             let input = ["aaa\na", "aaa\n\n", "aaa", "aa\n\naaaab"]
                 badLine = 6
                 badCol = 6
                 parser = Data.Attoparsec.Text.string "bc" <|> (Data.Attoparsec.Text.anyChar >> parser)
                 sink = sinkParser parser
+                sink' = sinkParserEither parser
             ea <- runExceptionT $ CL.sourceList input $$ sink
             case ea of
                 Left e ->
                     case fromException e of
                         Just pe -> do
                             errorPosition pe `shouldBe` Position badLine badCol
+            ea' <- CL.sourceList input $$ sink'
+            case ea' of
+                Left pe ->
+                    errorPosition pe `shouldBe` Position badLine badCol
         it "works after new line in text" $ do
             let input = ["aaa\n", "aaa\n\n", "aaa", "aa\nb\naaaa"]
                 badLine = 5
                 badCol = 1
                 parser = Data.Attoparsec.Text.endOfInput <|> (Data.Attoparsec.Text.notChar 'b' >> parser)
                 sink = sinkParser parser
+                sink' = sinkParserEither parser
             ea <- runExceptionT $ CL.sourceList input $$ sink
             case ea of
                 Left e ->
                     case fromException e of
                         Just pe -> do
                             errorPosition pe `shouldBe` Position badLine badCol
+            ea' <- CL.sourceList input $$ sink'
+            case ea' of
+                Left pe ->
+                    errorPosition pe `shouldBe` Position badLine badCol
         it "works after new line in bytestring" $ do
             let input = ["aaa\n", "aaa\n\n", "aaa", "aa\nb\naaaa"]
                 badLine = 5
                 badCol = 1
                 parser = Data.Attoparsec.ByteString.Char8.endOfInput <|> (Data.Attoparsec.ByteString.Char8.notChar 'b' >> parser)
                 sink = sinkParser parser
+                sink' = sinkParserEither parser
             ea <- runExceptionT $ CL.sourceList input $$ sink
             case ea of
                 Left e ->
                     case fromException e of
                         Just pe -> do
                             errorPosition pe `shouldBe` Position badLine badCol
+            ea' <- CL.sourceList input $$ sink'
+            case ea' of
+                Left pe ->
+                    errorPosition pe `shouldBe` Position badLine badCol
         it "works for first line" $ do
             let input = ["aab\na", "aaa\n\n", "aaa", "aab\n\naaaa"]
                 badLine = 1
                 badCol = 3
                 parser = Data.Attoparsec.Text.endOfInput <|> (Data.Attoparsec.Text.notChar 'b' >> parser)
                 sink = sinkParser parser
+                sink' = sinkParserEither parser
             ea <- runExceptionT $ CL.sourceList input $$ sink
             case ea of
                 Left e ->
                     case fromException e of
                         Just pe -> do
                             errorPosition pe `shouldBe` Position badLine badCol
+            ea' <- CL.sourceList input $$ sink'
+            case ea' of
+                Left pe ->
+                    errorPosition pe `shouldBe` Position badLine badCol
 
     describe "conduitParser" $ do
         it "parses a repeated stream" $ do


### PR DESCRIPTION
It can be convenient to feed a conduit into a parser without dragging in the exception machinery.

I don't know if you'll like the way I added it to the tests -- it sort of violates the "a test should test only one thing" rule, but there was also much less duplication this way.  I can re-do that if you prefer.
