### PR TITLE
Fixing broken Show instance for Codec

### DIFF
--- a/conduit-extra/Data/Conduit/Text.hs
+++ b/conduit-extra/Data/Conduit/Text.hs
@@ -73,9 +73,11 @@ data Codec = Codec
     | NewCodec T.Text (T.Text -> B.ByteString) (B.ByteString -> DecodeResult)
 
 instance Show Codec where
-    showsPrec d c = showParen (d > 10) $
-        showString "Codec " . shows (codecName c)
-
+    showsPrec d c = 
+        let (cnst, name) = case c of
+                Codec t _ _    -> ("Codec ", t)
+                NewCodec t _ _ -> ("NewCodec ", t)
+        in showParen (d > 10) $ showString cnst . shows name
 
 
 


### PR DESCRIPTION
The Show instance for `Codec` currently uses a record accessor that is a partial function, and therefore broken for all codecs using the `NewCodec` constructor. 
