### PR TITLE
ghc 7.10.1 RC1 requires FlexibleContexts

### DIFF
--- a/conduit-extra/test/Data/Conduit/TextSpec.hs
+++ b/conduit-extra/test/Data/Conduit/TextSpec.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts, OverloadedStrings #-}
 module Data.Conduit.TextSpec (spec) where
 
 import qualified Data.Conduit.Text as CT


### PR DESCRIPTION
https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10

"Compiler changes
Inferred type-signatures now may require to enable FlexibleContexts..."

Compiles with ghc 7.10.1 RC1 and 7.8.4.