### PR TITLE
Add split function to Data.Text.Conduit (closes #205)

### DIFF
--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -66,6 +66,7 @@ test-suite test
                    , conduit-extra
                    , base
                    , hspec >= 1.3
+                   , QuickCheck
 
                    , async
                    , attoparsec


### PR DESCRIPTION
Don't merge; this is missing changelog updates and documentation. I just thought these tests could address @snoyberg's [comment](https://github.com/snoyberg/conduit/issues/205#issuecomment-87275036) about not splitting correctly when the input is chunked. This test in particular:

```haskell
it "handles separators on a chunk boundary" $ do
    (CL.sourceList ["aX","Xb"] C.$= CT.split "XX" C.$$ CL.consume) ==
        [["a","b"]]
```