### PR TITLE
Make Binary.lines O(n) instead of O(n^2)

### DIFF
--- a/conduit-extra/Data/Conduit/Binary.hs
+++ b/conduit-extra/Data/Conduit/Binary.hs
@@ -345,20 +345,18 @@ drop n0 = go n0
 -- Since 0.3.0
 lines :: Monad m => Conduit S.ByteString m S.ByteString
 lines =
-    loop id
+    loop []
   where
     loop front = await >>= maybe (finish front) (go front)
 
     finish front =
-        let final = front S.empty
+        let final = S.concat $ reverse front
          in unless (S.null final) (yield final)
 
     go sofar more =
         case S.uncons second of
-            Just (_, second') -> yield (sofar first) >> go id second'
-            Nothing ->
-                let rest = sofar more
-                 in loop $ S.append rest
+            Just (_, second') -> yield (S.concat $ reverse $ first:sofar) >> go [] second'
+            Nothing -> loop $ more:sofar
       where
         (first, second) = S.breakByte 10 more
 

--- a/conduit-extra/Data/Conduit/Binary.hs
+++ b/conduit-extra/Data/Conduit/Binary.hs
@@ -347,16 +347,16 @@ lines :: Monad m => Conduit S.ByteString m S.ByteString
 lines =
     loop []
   where
-    loop front = await >>= maybe (finish front) (go front)
+    loop acc = await >>= maybe (finish acc) (go acc)
 
-    finish front =
-        let final = S.concat $ reverse front
+    finish acc =
+        let final = S.concat $ reverse acc
          in unless (S.null final) (yield final)
 
-    go sofar more =
+    go acc more =
         case S.uncons second of
-            Just (_, second') -> yield (S.concat $ reverse $ first:sofar) >> go [] second'
-            Nothing -> loop $ more:sofar
+            Just (_, second') -> yield (S.concat $ reverse $ first:acc) >> go [] second'
+            Nothing -> loop $ more:acc
       where
         (first, second) = S.breakByte 10 more
 


### PR DESCRIPTION
Given the benchmark:

    import Control.Monad.Trans.Resource
    import Data.Conduit.Binary as C
    import Data.Conduit as C
    import Data.Conduit.List as C
    import Data.Void
    import qualified Data.ByteString.Char8 as BS
    import Control.Monad
    import Control.Monad.IO.Class
    import System.Time.Extra
    import Numeric.Extra

    main = do
        let s = BS.singleton 'x'
        forM_ [0..1000] $ \i -> do
            (t, res) <- duration $ runConduit $ replicateM_ (i*10000) (yield s) =$= C.lines =$= C.map BS.length =$= C.fold (+) 0
            print (showDuration $ t / intToDouble i, res)

In other words, generate a lot of short bytestrings, call lines (which basically concats it, since there are no newlines), count the total number of lines and print the time per 10K characters, I see:

* Before this patch: at 10K it takes 0.01s, at 300K it takes 0.13s per 10K elements.
* After this patch: it takes 0.00s per 10K elements at all numbers.

The cause of the poor performance before was an O(n^2) term. Someone did the "append as a function trick" - which kinda works for lists, but doesn't work at all for bytestrings. I did the simpler (and in my experience, more performant) list that you reverse construction, which actually works as you then call `S.concat` once.