### PR TITLE
conduit-extra needs GHC >= 7.4

### DIFF
--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -32,7 +32,7 @@ Library
   if !os(windows)
       Exposed-modules: Data.Conduit.Network.Unix
 
-  Build-depends:       base                     >= 4            && < 5
+  Build-depends:       base                     >= 4.5          && < 5
                      , conduit                  >= 1.1          && < 1.3
 
                        -- No version bounds necessary, since they're inherited


### PR DESCRIPTION
```
Data/Conduit/Network/Unix.hs:2:14: Unsupported extension: PolyKinds
```

Revised: http://hackage.haskell.org/package/conduit-extra/revisions/
