### PR TITLE
Safe/Trustworthy for resourcet

### DIFF
--- a/resourcet/Control/Monad/Trans/Resource.hs
+++ b/resourcet/Control/Monad/Trans/Resource.hs
@@ -10,6 +10,7 @@
 #if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE ConstraintKinds #-}
 #endif
+{-# LANGUAGE Safe #-}
 -- | Allocate resources which are guaranteed to be released.
 --
 -- For more information, see <https://www.fpcomplete.com/user/snoyberg/library-documentation/resourcet>.
@@ -73,27 +74,11 @@ import qualified Control.Exception as E
 import Data.Monoid (Monoid)
 import qualified Control.Exception.Lifted as L
 
-import Control.Monad.Trans.Identity ( IdentityT)
-import Control.Monad.Trans.List     ( ListT    )
-import Control.Monad.Trans.Maybe    ( MaybeT   )
-import Control.Monad.Trans.Error    ( ErrorT, Error)
-import Control.Monad.Trans.Reader   ( ReaderT  )
-import Control.Monad.Trans.State    ( StateT   )
-import Control.Monad.Trans.Writer   ( WriterT  )
 import Control.Monad.Trans.Resource.Internal
-import Control.Monad.Trans.RWS      ( RWST     )
 
-import qualified Control.Monad.Trans.RWS.Strict    as Strict ( RWST   )
-import qualified Control.Monad.Trans.State.Strict  as Strict ( StateT )
-import qualified Control.Monad.Trans.Writer.Strict as Strict ( WriterT )
 import Control.Concurrent (ThreadId, forkIO)
 
-import Control.Monad.ST (ST)
-
-import qualified Control.Monad.ST.Lazy as Lazy
-
 import Data.Functor.Identity (Identity, runIdentity)
-import Control.Monad.Morph
 import Control.Monad.Catch (MonadThrow, throwM)
 import Control.Monad.Catch.Pure (CatchT, runCatchT)
 import Data.Acquire.Internal (ReleaseType (..))

--- a/resourcet/Control/Monad/Trans/Resource/Internal.hs
+++ b/resourcet/Control/Monad/Trans/Resource/Internal.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE Safe #-}
 
 module Control.Monad.Trans.Resource.Internal(
     InvalidAccess(..)
@@ -55,7 +56,6 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad (liftM)
 #endif
 import qualified Control.Exception as E
-import Control.Monad.ST (ST)
 import Control.Monad.Catch (MonadThrow (..), MonadCatch (..)
 #if MIN_VERSION_exceptions(0,6,0)
     , MonadMask (..)
@@ -69,20 +69,6 @@ import Data.Typeable
 import Data.Word(Word)
 import Prelude hiding (catch)
 import Data.Acquire.Internal (ReleaseType (..))
-
-#if __GLASGOW_HASKELL__ >= 704
-import Control.Monad.ST.Unsafe (unsafeIOToST)
-#else
-import Control.Monad.ST (unsafeIOToST)
-#endif
-
-#if __GLASGOW_HASKELL__ >= 704
-import qualified Control.Monad.ST.Lazy.Unsafe as LazyUnsafe
-#else
-import qualified Control.Monad.ST.Lazy as LazyUnsafe
-#endif
-
-import qualified Control.Monad.ST.Lazy as Lazy
 
 import Control.Monad.Morph
 

--- a/resourcet/Data/Acquire.hs
+++ b/resourcet/Data/Acquire.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Safe #-}
 -- | This was previously known as the Resource monad. However, that term is
 -- confusing next to the ResourceT transformer, so it has been renamed.
 module Data.Acquire

--- a/resourcet/Data/Acquire/Internal.hs
+++ b/resourcet/Data/Acquire/Internal.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE Trustworthy #-}
 module Data.Acquire.Internal
     ( Acquire (..)
     , Allocated (..)


### PR DESCRIPTION
This makes it possible to use resourcet in Safe Haskell. I've removed a bunch of imports that appear (and are reported as) redundant, but suspect I'm missing something.

Tested with LTS Haskell 2.20 (GHC 7.8.4), but no other versions.