### PR TITLE
Mark Control.Monad.Trans.Resource.Internal as Trustworthy for GHC < 7.07

### DIFF
--- a/resourcet/Control/Monad/Trans/Resource.hs
+++ b/resourcet/Control/Monad/Trans/Resource.hs
@@ -10,9 +10,7 @@
 #if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE ConstraintKinds #-}
 #endif
-#if __GLASGOW_HASKELL__ >= 707
 {-# LANGUAGE Safe #-}
-#endif
 -- | Allocate resources which are guaranteed to be released.
 --
 -- For more information, see <https://www.fpcomplete.com/user/snoyberg/library-documentation/resourcet>.

--- a/resourcet/Control/Monad/Trans/Resource/Internal.hs
+++ b/resourcet/Control/Monad/Trans/Resource/Internal.hs
@@ -7,10 +7,12 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
--- Can only turn on SafeHaskell when using a newer GHC, otherwise we get build
+-- Can only mark as Safe when using a newer GHC, otherwise we get build
 -- failures due to the manual Typeable instance below.
 #if __GLASGOW_HASKELL__ >= 707
 {-# LANGUAGE Safe #-}
+#else
+{-# LANGUAGE Trustworthy #-}
 #endif
 
 module Control.Monad.Trans.Resource.Internal(

--- a/resourcet/Data/Acquire.hs
+++ b/resourcet/Data/Acquire.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 707
 {-# LANGUAGE Safe #-}
-#endif
 -- | This was previously known as the Resource monad. However, that term is
 -- confusing next to the ResourceT transformer, so it has been renamed.
 module Data.Acquire


### PR DESCRIPTION
Hopefully this will give the best of both worlds.