### PR TITLE
Safe Haskell for conduit and Data.Conduit.Lazy

### DIFF
--- a/conduit-extra/Data/Conduit/Lazy.hs
+++ b/conduit-extra/Data/Conduit/Lazy.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE Trustworthy #-}
 -- | Use lazy I\/O for consuming the contents of a source. Warning: All normal
 -- warnings of lazy I\/O apply. In particular, if you are using this with a
 -- @ResourceT@ transformer, you must force the list to be evaluated before

--- a/conduit/Data/Conduit.hs
+++ b/conduit/Data/Conduit.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE Safe #-}
 -- | If this is your first time with conduit, you should probably start with
 -- the tutorial:
 -- <https://haskell.fpcomplete.com/user/snoyberg/library-documentation/conduit-overview>.

--- a/conduit/Data/Conduit/Internal.hs
+++ b/conduit/Data/Conduit/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Safe #-}
 {-# OPTIONS_HADDOCK not-home #-}
 module Data.Conduit.Internal
     ( -- * Pipe

--- a/conduit/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/Data/Conduit/Internal/Conduit.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_HADDOCK not-home #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE CPP #-}
@@ -6,8 +7,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE Trustworthy #-}
 module Data.Conduit.Internal.Conduit
     ( -- ** Types
       ConduitM (..)

--- a/conduit/Data/Conduit/Internal/Fusion.hs
+++ b/conduit/Data/Conduit/Internal/Fusion.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE Trustworthy #-}
 module Data.Conduit.Internal.Fusion
     ( -- ** Types
       Step (..)

--- a/conduit/Data/Conduit/Internal/List/Stream.hs
+++ b/conduit/Data/Conduit/Internal/List/Stream.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE Trustworthy #-}
 module Data.Conduit.Internal.List.Stream where
 
 import           Control.Monad (liftM)

--- a/conduit/Data/Conduit/Internal/Pipe.hs
+++ b/conduit/Data/Conduit/Internal/Pipe.hs
@@ -6,8 +6,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ImpredicativeTypes #-}
+{-# LANGUAGE Trustworthy #-}
 module Data.Conduit.Internal.Pipe
     ( -- ** Types
       Pipe (..)

--- a/conduit/Data/Conduit/Lift.hs
+++ b/conduit/Data/Conduit/Lift.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE Safe #-}
 -- | Allow monad transformers to be run\/eval\/exec in a section of conduit
 -- rather then needing to run across the whole conduit.  The circumvents many
 -- of the problems with breaking the monad transformer laws.  For more

--- a/conduit/Data/Conduit/List.hs
+++ b/conduit/Data/Conduit/List.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE Trustworthy #-}
 -- | Higher-level functions to interact with the elements of a stream. Most of
 -- these are based on list functions.
 --


### PR DESCRIPTION
Because RULES pragmas don't fire if defined in Safe modules, most are marked as Trustworthy.