### PR TITLE
Have test-cereal-conduit depend on the library

### DIFF
--- a/cereal-conduit/cereal-conduit.cabal
+++ b/cereal-conduit/cereal-conduit.cabal
@@ -30,10 +30,12 @@ library
 
 Test-Suite test-cereal-conduit
     type: exitcode-stdio-1.0
-    main-is: Test/Main.hs
+    main-is: Main.hs
+    hs-source-dirs: Test
     build-depends: base
                  , conduit
                  , cereal
+                 , cereal-conduit
                  , bytestring
                  --, test-framework-hunit
                  , HUnit


### PR DESCRIPTION
This avoids unnecessary recompilation, and fixes the "stack test
--coverage" results for this package.

https://github.com/commercialhaskell/stack/issues/1008
https://github.com/commercialhaskell/stack/issues/1009