### PR TITLE
Fix inconsistent void dependency

### DIFF
--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -54,10 +54,11 @@ test-suite test
                    , transformers
                    , mtl
                    , resourcet
-                   , void
                    , containers
                    , exceptions >= 0.6
                    , safe
+    if !impl(ghc>=7.9)
+        build-depends: void
     ghc-options:     -Wall
 
 --test-suite doctests


### PR DESCRIPTION
`void` must be included only when compiling with GHC versions prior to 7.9.x. The library had that restriction already, but it was missing in the spec of the test suite.