### PR TITLE
Allow transformers-compat 0.5

### DIFF
--- a/resourcet/resourcet.cabal
+++ b/resourcet/resourcet.cabal
@@ -23,7 +23,7 @@ Library
                      , monad-control            >= 0.3.1        && < 1.1
                      , containers
                      , transformers             >= 0.2.2        && < 0.5
-                     , transformers-compat      >= 0.3          && < 0.5
+                     , transformers-compat      >= 0.3          && < 0.6
                      , mtl                      >= 2.0          && < 2.3
                      , mmorph
                      , exceptions               >= 0.5


### PR DESCRIPTION
The tests pass on GHC 7.10.3, so I'm pretty sure that this is okay.