### PR TITLE
Fix conduit and resourcet on GHC 8.0

### DIFF
--- a/conduit/Data/Conduit/Internal/Pipe.hs
+++ b/conduit/Data/Conduit/Internal/Pipe.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE Trustworthy #-}
 module Data.Conduit.Internal.Pipe
     ( -- ** Types

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -32,7 +32,7 @@ Library
                      , exceptions               >= 0.6
                      , lifted-base              >= 0.1
                      , transformers-base        >= 0.4.1        && < 0.5
-                     , transformers             >= 0.2.2        && < 0.5
+                     , transformers             >= 0.2.2        && < 0.6
                      , mtl
                      , mmorph
   if !impl(ghc>=7.9)

--- a/resourcet/Control/Monad/Trans/Resource.hs
+++ b/resourcet/Control/Monad/Trans/Resource.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE ImpredicativeTypes #-}
 #if __GLASGOW_HASKELL__ >= 704
 {-# LANGUAGE ConstraintKinds #-}
 #endif
@@ -97,12 +96,12 @@ register = liftResourceT . registerRIO
 --
 -- Since 0.3.0
 release :: MonadIO m => ReleaseKey -> m ()
-release (ReleaseKey istate rk) = liftIO $ release' istate rk  
+release (ReleaseKey istate rk) = liftIO $ release' istate rk
     (maybe (return ()) id)
 
 -- | Unprotect resource from cleanup actions, this allowes you to send
 -- resource into another resourcet process and reregister it there.
--- It returns an release action that should be run in order to clean 
+-- It returns an release action that should be run in order to clean
 -- resource or Nothing in case if resource is already freed.
 --
 -- Since 0.4.5
@@ -129,7 +128,7 @@ allocate a = liftResourceT . allocateRIO a
 --
 -- Since 0.3.0
 resourceMask :: MonadResource m => ((forall a. ResourceT IO a -> ResourceT IO a) -> ResourceT IO b) -> m b
-resourceMask = liftResourceT . resourceMaskRIO
+resourceMask r = liftResourceT (resourceMaskRIO r)
 
 allocateRIO :: IO a -> (a -> IO ()) -> ResourceT IO (ReleaseKey, a)
 allocateRIO acquire rel = ResourceT $ \istate -> liftIO $ E.mask $ \restore -> do

--- a/resourcet/resourcet.cabal
+++ b/resourcet/resourcet.cabal
@@ -22,7 +22,7 @@ Library
                      , transformers-base        >= 0.4.4        && < 0.5
                      , monad-control            >= 0.3.1        && < 1.1
                      , containers
-                     , transformers             >= 0.2.2        && < 0.5
+                     , transformers             >= 0.2.2        && < 0.6
                      , transformers-compat      >= 0.3          && < 0.6
                      , mtl                      >= 2.0          && < 2.3
                      , mmorph


### PR DESCRIPTION
This requires two small changes:

* The `ImpredicativeTypes` extension pretty much can't be used on GHC 8.0 due to a [type inference regression](https://ghc.haskell.org/trac/ghc/ticket/11319). `ImpredicativeTypes` has been pretty much unsupported for a while though, so removing it is probably for the best.
* Without `ImpredicativeTypes`, the definition of `resourceMask` had to be expanded.