### PR TITLE
Proposed `fuseEither` combinator

### DIFF
--- a/conduit/Data/Conduit.hs
+++ b/conduit/Data/Conduit.hs
@@ -23,6 +23,7 @@ module Data.Conduit
     , fuseBoth
     , fuseBothMaybe
     , fuseUpstream
+    , fuseEither
 
       -- ** Primitives
     , await

--- a/conduit/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/Data/Conduit/Internal/Conduit.hs
@@ -829,7 +829,7 @@ fuseEither (ConduitM left0) (ConduitM right0) = ConduitM $ \rest ->
             case left of
                 HaveOutput left' final' o -> goRight final' left' (rp o)
                 NeedInput left' lc        -> NeedInput (recurse . left') (recurse . lc)
-                Done r1                   -> PipeM (final >> return (rest (Left r1)))
+                Done r1                   -> PipeM (return (rest (Left r1)))
                 PipeM mp                  -> PipeM (liftM recurse mp)
                 Leftover left' i          -> Leftover (recurse left') i
           where


### PR DESCRIPTION
As discussed on [Haskell Cafe](https://mail.haskell.org/pipermail/haskell-cafe/2016-February/123132.html) I'd quite like to be able to fuse two conduits together and return the result of whichever one exits first.

The attached PR represents a bit of a lucky guess, in the sense that it compiles and passes a few sanity-check tests, but I don't know whether it really makes sense or whether it does something horrible in more advanced cases. It's also basically a copy-paste job from the definition of `(=$=)` and currently doesn't have documentation, both of which I'm happy to fix with a bit of guidance.

