### PR TITLE
Silence various warnings.

### DIFF
--- a/conduit-extra/Data/Conduit/Attoparsec.hs
+++ b/conduit-extra/Data/Conduit/Attoparsec.hs
@@ -105,7 +105,7 @@ instance AttoparsecInput T.Text where
         f (Position l c) ch | ch == '\n' = Position (l + 1) 0
                             | otherwise = Position l (c + 1)
     stripFromEnd (TI.Text arr1 off1 len1) (TI.Text _ _ len2) =
-        TI.textP arr1 off1 (len1 - len2)
+        TI.text arr1 off1 (len1 - len2)
 
 -- | Convert an Attoparsec 'A.Parser' into a 'Sink'. The parser will
 -- be streamed bytes until it returns 'A.Done' or 'A.Fail'.

--- a/conduit-extra/Data/Conduit/Binary.hs
+++ b/conduit-extra/Data/Conduit/Binary.hs
@@ -55,7 +55,9 @@ import Control.Monad.Trans.Resource (allocate, release)
 import Control.Monad.Trans.Class (lift)
 import qualified System.IO as IO
 import Data.Word (Word8, Word64)
+#if (__GLASGOW_HASKELL__ < 710)
 import Control.Applicative ((<$>))
+#endif
 import System.Directory (getTemporaryDirectory, removeFile)
 import Data.ByteString.Lazy.Internal (defaultChunkSize)
 import Data.ByteString.Internal (ByteString (PS), inlinePerformIO)
@@ -65,6 +67,7 @@ import Foreign.Ptr (plusPtr)
 import Foreign.Storable (peek)
 import GHC.ForeignPtr           (mallocPlainForeignPtrBytes)
 import Control.Monad.Trans.Resource (MonadResource)
+
 
 -- | Stream the contents of a file as binary data.
 --
@@ -373,7 +376,7 @@ lines =
             Just (_, second') -> yield (S.concat $ reverse $ first:acc) >> go [] second'
             Nothing -> loop $ more:acc
       where
-        (first, second) = S.breakByte 10 more
+        (first, second) = S.break (== 10) more
 
 -- | Stream the chunks from a lazy bytestring.
 --

--- a/conduit-extra/Data/Conduit/Lazy.hs
+++ b/conduit-extra/Data/Conduit/Lazy.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE Trustworthy #-}
+
+{-# OPTIONS_GHC -fno-warn-deprecations #-} -- Suppress warnings around Control.Monad.Trans.Error
 -- | Use lazy I\/O for consuming the contents of a source. Warning: All normal
 -- warnings of lazy I\/O apply. In particular, if you are using this with a
 -- @ResourceT@ transformer, you must force the list to be evaluated before
@@ -31,7 +33,9 @@ import qualified Control.Monad.Trans.RWS.Strict    as Strict ( RWST   )
 import qualified Control.Monad.Trans.State.Strict  as Strict ( StateT )
 import qualified Control.Monad.Trans.Writer.Strict as Strict ( WriterT )
 
+#if (__GLASGOW_HASKELL__ < 710)
 import Data.Monoid (Monoid)
+#endif
 import Control.Monad.ST (ST)
 import qualified Control.Monad.ST.Lazy as Lazy
 import Data.Functor.Identity (Identity)

--- a/conduit-extra/Data/Conduit/Network.hs
+++ b/conduit-extra/Data/Conduit/Network.hs
@@ -38,17 +38,14 @@ module Data.Conduit.Network
     , SN.HostPreference
     ) where
 
-import Prelude hiding (catch)
+import Prelude
 import Data.Conduit
-import qualified Network.Socket as NS
 import Network.Socket (Socket)
-import Network.Socket.ByteString (sendAll, recv)
+import Network.Socket.ByteString (sendAll)
 import Data.ByteString (ByteString)
 import qualified GHC.Conc as Conc (yield)
 import qualified Data.ByteString as S
-import qualified Data.ByteString.Char8 as S8
 import Control.Monad.IO.Class (MonadIO (liftIO))
-import Control.Exception (throwIO, SomeException, try, finally, bracket, IOException, catch)
 import Control.Monad (unless, void)
 import Control.Monad.Trans.Control (MonadBaseControl, control, liftBaseWith)
 import Control.Monad.Trans.Class (lift)
@@ -81,7 +78,10 @@ sinkSocket socket =
   where
     loop = await >>= maybe (return ()) (\bs -> lift (liftIO $ sendAll socket bs) >> loop)
 
+serverSettings :: Int -> SN.HostPreference -> SN.ServerSettings
 serverSettings = SN.serverSettingsTCP
+
+clientSettings :: Int -> ByteString -> SN.ClientSettings
 clientSettings = SN.clientSettingsTCP
 
 appSource :: (SN.HasReadWrite ad, MonadIO m) => ad -> Producer m ByteString

--- a/conduit-extra/Data/Conduit/Network/UDP.hs
+++ b/conduit-extra/Data/Conduit/Network/UDP.hs
@@ -13,8 +13,7 @@ module Data.Conduit.Network.UDP
     ) where
 
 import Data.Conduit
-import Network.Socket (AddrInfo, SockAddr, Socket)
-import qualified Network.Socket as NS
+import Network.Socket (Socket)
 import Network.Socket.ByteString (recvFrom, send, sendAll, sendTo, sendAllTo)
 import Data.ByteString (ByteString)
 import Control.Monad.IO.Class (MonadIO (liftIO))

--- a/conduit-extra/Data/Conduit/Network/Unix.hs
+++ b/conduit-extra/Data/Conduit/Network/Unix.hs
@@ -26,20 +26,11 @@ module Data.Conduit.Network.Unix
     , SN.setAfterBind
     ) where
 
-import Data.Conduit
-import Network.Socket (Socket)
-import qualified Network.Socket as NS
 import Data.Conduit.Network (appSource, appSink, sourceSocket, sinkSocket)
 import qualified Data.Streaming.Network as SN
-import Control.Monad.IO.Class (MonadIO (liftIO))
-import Control.Exception (throwIO, SomeException, try, finally, bracket,
-                          bracketOnError, catch)
-import Control.Monad (forever, void)
-import Control.Monad.Trans.Control (control)
-import Control.Concurrent (forkIO)
-import System.Directory (removeFile)
-import System.IO.Error (isDoesNotExistError)
-import Control.Monad.Trans.Resource (MonadBaseControl)
 
+clientSettings :: FilePath -> SN.ClientSettingsUnix
 clientSettings = SN.clientSettingsUnix
+
+serverSettings :: FilePath -> SN.ServerSettingsUnix
 serverSettings = SN.serverSettingsUnix

--- a/conduit-extra/Data/Conduit/Process.hs
+++ b/conduit-extra/Data/Conduit/Process.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 -- | A full tutorial for this module is available on FP School of Haskell:
 -- <https://www.fpcomplete.com/user/snoyberg/library-documentation/data-conduit-process>.
@@ -31,7 +32,9 @@ import Data.Conduit.Binary (sourceHandle, sinkHandle)
 import Data.ByteString (ByteString)
 import Control.Concurrent.Async (runConcurrently, Concurrently(..))
 import Control.Monad.Catch (MonadMask, onException, throwM, finally)
+#if (__GLASGOW_HASKELL__ < 710)
 import Control.Applicative ((<$>), (<*>))
+#endif
 
 instance (r ~ (), MonadIO m, i ~ ByteString) => InputSource (ConduitM i o m r) where
     isStdStream = (\(Just h) -> return $ sinkHandle h, Just CreatePipe)

--- a/conduit-extra/Data/Conduit/Text.hs
+++ b/conduit-extra/Data/Conduit/Text.hs
@@ -38,7 +38,6 @@ module Data.Conduit.Text
     , detectUtf
     ) where
 
-import qualified Prelude
 import           Prelude hiding (head, drop, takeWhile, lines, zip, zip3, zipWith, zipWith3, take, dropWhile)
 
 import qualified Control.Exception as Exc
@@ -61,7 +60,7 @@ import Data.Streaming.Text
 --
 -- Since 0.3.0
 data Codec = Codec
-    { codecName :: T.Text
+    { _codecName :: T.Text
     , codecEncode
         :: T.Text
         -> (B.ByteString, Maybe (TextException, T.Text))
@@ -74,7 +73,7 @@ data Codec = Codec
     | NewCodec T.Text (T.Text -> B.ByteString) (B.ByteString -> DecodeResult)
 
 instance Show Codec where
-    showsPrec d c = 
+    showsPrec d c =
         let (cnst, name) = case c of
                 Codec t _ _    -> ("Codec ", t)
                 NewCodec t _ _ -> ("NewCodec ", t)
@@ -150,7 +149,7 @@ decodeNew
     -> Int
     -> (B.ByteString -> DecodeResult)
     -> Conduit B.ByteString m T.Text
-decodeNew onFailure name =
+decodeNew onFailure _name =
     loop
   where
     loop consumed dec =


### PR DESCRIPTION
Include missing type signature, un-used imports and un-used fields on records.