### PR TITLE
network-conduit-tls: Expose ApplicationStartTLS

### DIFF
--- a/network-conduit-tls/Data/Conduit/Network/TLS.hs
+++ b/network-conduit-tls/Data/Conduit/Network/TLS.hs
@@ -5,8 +5,10 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE KindSignatures #-}
 module Data.Conduit.Network.TLS
-    ( -- * Server
-      TLSConfig
+    ( -- * Common
+      ApplicationStartTLS
+      -- * Server
+    , TLSConfig
     , tlsConfigBS
     , tlsConfig
     , tlsConfigChainBS


### PR DESCRIPTION
This should also fix documentation issues.

(See `runTCPServerStartTLS` at https://hackage.haskell.org/package/network-conduit-tls-1.2.0.1/docs/Data-Conduit-Network-TLS.html for example of current issues)