### PR TITLE
In zipConduitApp, left bias not respected mixing monadic and non-monadic conduits

### DIFF
--- a/conduit/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/Data/Conduit/Internal/Conduit.hs
@@ -540,6 +540,8 @@ zipConduitApp
     -> ConduitM i o m y
 zipConduitApp (ConduitM left0) (ConduitM right0) = ConduitM $ \rest -> let
     go _ _ (Done f) (Done x) = rest (f x)
+    go finalX finalY (PipeM mx) y = PipeM (flip (go finalX finalY) y `liftM` mx)
+    go finalX finalY x (PipeM my) = PipeM (go finalX finalY x `liftM` my)
     go _ finalY (HaveOutput x finalX o) y = HaveOutput
         (go finalX finalY x y)
         (finalX >> finalY)
@@ -550,8 +552,6 @@ zipConduitApp (ConduitM left0) (ConduitM right0) = ConduitM $ \rest -> let
         o
     go _ _ (Leftover _ i) _ = absurd i
     go _ _ _ (Leftover _ i) = absurd i
-    go finalX finalY (PipeM mx) y = PipeM (flip (go finalX finalY) y `liftM` mx)
-    go finalX finalY x (PipeM my) = PipeM (go finalX finalY x `liftM` my)
     go finalX finalY (NeedInput px cx) (NeedInput py cy) = NeedInput
         (\i -> go finalX finalY (px i) (py i))
         (\u -> go finalX finalY (cx u) (cy u))

--- a/conduit/test/Data/Conduit/Extra/ZipConduitSpec.hs
+++ b/conduit/test/Data/Conduit/Extra/ZipConduitSpec.hs
@@ -24,3 +24,11 @@ spec = describe "Data.Conduit.Extra.ZipConduit" $ do
             sink = CL.consume
         res <- src $$ conduit =$ sink
         res `shouldBe` [2, 1, 1, 3, 2, 2, 4, 3, 3, 12]
+    it "ZipConduitMonad" $ do
+        let src = mapM_ yield [1..3 :: Int]
+            conduit1 = CL.mapM (pure . (+1))
+            conduit2 = CL.map id
+            conduit = getZipConduit $ ZipConduit conduit1 <* ZipConduit conduit2
+            sink = CL.consume
+        res <- src $$ conduit =$ sink
+        res `shouldBe` [2, 1, 3, 2, 4, 3]


### PR DESCRIPTION
zipConduitApp first looks for output, then evaluates monadic pipes. This results in non-monadic output always coming before monadic output, potentially violating the left bias. Monads should be evaluated first to ensure left bias is always respected.

Also adds a test that fails given the current implementation of zipConduitApp.