### PR TITLE
Fix alignment restrictions

### DIFF
--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -33,6 +33,10 @@ Library
   if !os(windows)
       Exposed-modules: Data.Conduit.Network.Unix
 
+  if arch(x86_64) || arch(i386)
+      -- These architectures are able to perform unaligned memory accesses
+      cpp-options: -DALLOW_UNALIGNED_ACCESS
+
   Build-depends:       base                     >= 4.5          && < 5
                      , conduit                  >= 1.1          && < 1.3
 


### PR DESCRIPTION
The testsuite for conduit-extra fails on [armhf](https://buildd.debian.org/status/fetch.php?pkg=haskell-conduit-extra&arch=armhf&ver=1.1.13.1-1&stamp=1466081154) architectures because of unaligned memory access.

According to the docs, the peek and poke functions might require properly aligned addresses to function correctly. This is architecture dependent; thus, portable code should ensure that when peeking or poking values of some type a, the alignment constraint for a, as given by the function alignment is fulfilled.

Here I provide two patches that ensure that alignment constraints are fulfilled. The implementation requires one extra copy, but makes the code portable.

I have patched the code in two steps, first the sinkStorable implementation and then the testsuite. This hopefully demonstrates that the patches introduce no regressions.