### PR TITLE
Export the yieldM on ConduitM.

### DIFF
--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.2.7
+
+* Expose yieldM for ConduitM [#270](https://github.com/snoyberg/conduit/pull/270)
+
 ## 1.2.6.6
 
 * Fix test suite compilation on older GHCs

--- a/conduit/Data/Conduit.hs
+++ b/conduit/Data/Conduit.hs
@@ -27,6 +27,7 @@ module Data.Conduit
       -- ** Primitives
     , await
     , yield
+    , yieldM
     , leftover
     , runConduit
 

--- a/conduit/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/Data/Conduit/Internal/Conduit.hs
@@ -842,6 +842,9 @@ yield :: Monad m
 yield o = yieldOr o (return ())
 {-# INLINE yield #-}
 
+-- | Send a monadic value downstream for the next component to consume.
+--
+-- @since 1.2.7
 yieldM :: Monad m => m o -> ConduitM i o m ()
 yieldM mo = lift mo >>= yield
 {-# INLINE yieldM #-}
@@ -853,8 +856,8 @@ yieldM mo = lift mo >>= yield
 --
 -- /Note/: it is highly encouraged to only return leftover values from input
 -- already consumed from upstream.
---
 -- Since 0.5.0
+--
 leftover :: i -> ConduitM i o m ()
 leftover i = ConduitM $ \rest -> Leftover (rest ()) i
 {-# INLINE leftover #-}


### PR DESCRIPTION
Not sure the reasons why this isn't exported but I find it rather useful for code I want to keep pure and only mix into conduit at the last minute.

eg 
```haskell
deriveFeatures :: Monad m =>  Conduit Row (EitherT RowError m) OtherRow
deriveFeatures od = awaitForever (yieldM . hoistEither . deriveFeatures')

deriveFeatures' :: Row -> Either JoinOfferError OtherRow
deriveFeatures' = ....
```
