### PR TITLE
Use `mask_` now that 'allocate' does not use 'restore'

### DIFF
--- a/resourcet/Control/Monad/Trans/Resource.hs
+++ b/resourcet/Control/Monad/Trans/Resource.hs
@@ -131,7 +131,7 @@ resourceMask :: MonadResource m => ((forall a. ResourceT IO a -> ResourceT IO a)
 resourceMask r = liftResourceT (resourceMaskRIO r)
 
 allocateRIO :: IO a -> (a -> IO ()) -> ResourceT IO (ReleaseKey, a)
-allocateRIO acquire rel = ResourceT $ \istate -> liftIO $ E.mask $ \restore -> do
+allocateRIO acquire rel = ResourceT $ \istate -> liftIO $ E.mask_ $ do
     a <- acquire
     key <- register' istate $ rel a
     return (key, a)


### PR DESCRIPTION
This should avoid potential compiler warnings.