### PR TITLE
Deprecated older synonyms and operators (fixes #283)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ matrix:
   #- env: BUILD=cabal GHCVER=7.2.2 CABALVER=1.16 HAPPYVER=1.19.5 ALEXVER=3.1.7
   #  compiler: ": #GHC 7.2.2"
   #  addons: {apt: {packages: [cabal-install-1.16,ghc-7.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=7.4.2 CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 7.4.2"
-    addons: {apt: {packages: [cabal-install-head,ghc-7.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
+  #- env: BUILD=cabal GHCVER=7.4.2 CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
+  #  compiler: ": #GHC 7.4.2"
+  #  addons: {apt: {packages: [cabal-install-head,ghc-7.4.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=7.6.3 CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
     compiler: ": #GHC 7.6.3"
     addons: {apt: {packages: [cabal-install-head,ghc-7.6.3,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}

--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.2.11
+
+* Perform deprecations of old identifiers
+* Re-export `Void` from `Data.Conduit`
+
 ## 1.2.10
 
 * Add `PrimMonad` instances for `ConduitM` and `Pipe`

--- a/conduit/Data/Conduit/Internal.hs
+++ b/conduit/Data/Conduit/Internal.hs
@@ -5,6 +5,7 @@ module Data.Conduit.Internal
       module Data.Conduit.Internal.Pipe
       -- * Conduit
     , module Data.Conduit.Internal.Conduit
+    , module Data.Conduit.Internal.Deprecated
       -- * Fusion (highly experimental!!!)
     , module Data.Conduit.Internal.Fusion
     ) where
@@ -14,5 +15,6 @@ import           Data.Conduit.Internal.Conduit hiding (addCleanup, await,
                                                 leftover, mapInput, mapOutput,
                                                 mapOutputMaybe, transPipe,
                                                 yield, yieldM, yieldOr)
+import           Data.Conduit.Internal.Deprecated
 import           Data.Conduit.Internal.Pipe
 import           Data.Conduit.Internal.Fusion

--- a/conduit/Data/Conduit/Internal/Deprecated.hs
+++ b/conduit/Data/Conduit/Internal/Deprecated.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE Trustworthy #-}
+module Data.Conduit.Internal.Deprecated
+  ( Source
+  , Sink
+  , Conduit
+  , Producer
+  , Consumer
+  , ($$)
+  , ($=)
+  , (=$)
+  , (=$=)
+  , connect
+  ) where
+
+import Data.Conduit.Internal.Conduit
+import Data.Void (Void)
+
+-- | Provides a stream of output values, without consuming any input or
+-- producing a final result.
+--
+-- Since 0.5.0
+type Source m o = ConduitM () o m ()
+{-# DEPRECATED Source "Use ConduitM directly instead" #-}
+
+-- | A component which produces a stream of output values, regardless of the
+-- input stream. A @Producer@ is a generalization of a @Source@, and can be
+-- used as either a @Source@ or a @Conduit@.
+--
+-- Since 1.0.0
+type Producer m o = forall i. ConduitM i o m ()
+{-# DEPRECATED Producer "Use ConduitM directly instead" #-}
+
+-- | Consumes a stream of input values and produces a final result, without
+-- producing any output.
+--
+-- > type Sink i m r = ConduitM i Void m r
+--
+-- Since 0.5.0
+type Sink i = ConduitM i Void
+{-# DEPRECATED Sink "Use ConduitM directly instead" #-}
+
+-- | A component which consumes a stream of input values and produces a final
+-- result, regardless of the output stream. A @Consumer@ is a generalization of
+-- a @Sink@, and can be used as either a @Sink@ or a @Conduit@.
+--
+-- Since 1.0.0
+type Consumer i m r = forall o. ConduitM i o m r
+{-# DEPRECATED Consumer "Use ConduitM directly instead" #-}
+
+-- | Consumes a stream of input values and produces a stream of output values,
+-- without producing a final result.
+--
+-- Since 0.5.0
+type Conduit i m o = ConduitM i o m ()
+{-# DEPRECATED Conduit "Use ConduitM directly instead" #-}
+
+-- | The connect operator, which pulls data from a source and pushes to a sink.
+-- If you would like to keep the @Source@ open to be used for other
+-- operations, use the connect-and-resume operator '$$+'.
+--
+-- Since 0.4.0
+($$) :: Monad m => Source m a -> Sink a m b -> m b
+src $$ sink = do
+    (rsrc, res) <- src $$+ sink
+    rsrc $$+- return ()
+    return res
+{-# INLINE [1] ($$) #-}
+{-# DEPRECATED ($$) "Use .| and runConduit instead" #-}
+
+-- | Named function synonym for '$$'.
+--
+-- Since 1.2.3
+connect :: Monad m
+        => ConduitM () a m ()
+        -> ConduitM a Void m b
+        -> m b
+connect = ($$)
+{-# DEPRECATED connect "Use runConduit and .| instead" #-}
+
+-- | A synonym for '=$=' for backwards compatibility.
+--
+-- Since 0.4.0
+($=) :: Monad m => Conduit a m b -> ConduitM b c m r -> ConduitM a c m r
+($=) = (=$=)
+{-# INLINE [0] ($=) #-}
+{-# RULES "conduit: $= is =$=" ($=) = (=$=) #-}
+{-# DEPRECATED ($=) "Use .| instead" #-}
+
+-- | A synonym for '=$=' for backwards compatibility.
+--
+-- Since 0.4.0
+(=$) :: Monad m => Conduit a m b -> ConduitM b c m r -> ConduitM a c m r
+(=$) = (=$=)
+{-# INLINE [0] (=$) #-}
+{-# RULES "conduit: =$ is =$=" (=$) = (=$=) #-}
+{-# DEPRECATED (=$) "Use .| instead" #-}
+
+-- | Fusion operator, combining two @Conduit@s together into a new @Conduit@.
+--
+-- Both @Conduit@s will be closed when the newly-created @Conduit@ is closed.
+--
+-- Leftover data returned from the right @Conduit@ will be discarded.
+--
+-- @since 0.4.0
+(=$=) :: Monad m => Conduit a m b -> ConduitM b c m r -> ConduitM a c m r
+(=$=) = fuse
+{-# INLINE [0] (=$=) #-}
+{-# DEPRECATED (=$=) "Use .| instead" #-}
+
+infixr 0 $$
+infixl 1 $=
+infixr 2 =$
+infixr 2 =$=

--- a/conduit/Data/Conduit/Internal/Fusion.hs
+++ b/conduit/Data/Conduit/Internal/Fusion.hs
@@ -62,11 +62,11 @@ fuseStream :: Monad m
            => ConduitWithStream a b m ()
            -> ConduitWithStream b c m r
            -> ConduitWithStream a c m r
-fuseStream (ConduitWithStream a x) (ConduitWithStream b y) = ConduitWithStream (a =$= b) (y . x)
+fuseStream (ConduitWithStream a x) (ConduitWithStream b y) = ConduitWithStream (a .| b) (y . x)
 {-# INLINE fuseStream #-}
 
 {-# RULES "conduit: fuseStream" forall left right.
-        unstream left =$= unstream right = unstream (fuseStream left right)
+        unstream left .| unstream right = unstream (fuseStream left right)
   #-}
 
 runStream :: Monad m
@@ -111,7 +111,7 @@ connectStream (ConduitWithStream _ stream) (ConduitWithStream _ f) =
 {-# INLINE connectStream #-}
 
 {-# RULES "conduit: connectStream" forall left right.
-        unstream left $$ unstream right = connectStream left right
+        runConduit (unstream left .| unstream right) = connectStream left right
   #-}
 
 connectStream1 :: Monad m
@@ -136,7 +136,7 @@ connectStream1 (ConduitWithStream _ fstream) (ConduitM sink0) =
 {-# INLINE connectStream1 #-}
 
 {-# RULES "conduit: connectStream1" forall left right.
-        unstream left $$ right = connectStream1 left right
+        runConduit (unstream left .| right) = connectStream1 left right
   #-}
 
 {-

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -34,7 +34,7 @@ Library
   other-modules:       Data.Conduit.Internal.Pipe
                        Data.Conduit.Internal.Conduit
                        Data.Conduit.Internal.Deprecated
-  Build-depends:       base                     >= 4.5          && < 5
+  Build-depends:       base                     >= 4.6          && < 5
                      , resourcet                >= 1.1          && < 1.2
                      , exceptions               >= 0.6
                      , lifted-base              >= 0.1

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -1,5 +1,5 @@
 Name:                conduit
-Version:             1.2.10
+Version:             1.2.11
 Synopsis:            Streaming data processing library.
 description:
     `conduit` is a solution to the streaming data problem, allowing for production,
@@ -33,6 +33,7 @@ Library
                        Data.Conduit.Internal.List.Stream
   other-modules:       Data.Conduit.Internal.Pipe
                        Data.Conduit.Internal.Conduit
+                       Data.Conduit.Internal.Deprecated
   Build-depends:       base                     >= 4.5          && < 5
                      , resourcet                >= 1.1          && < 1.2
                      , exceptions               >= 0.6


### PR DESCRIPTION
This implements the least painful bits of #283: deprecating old stuff without changing the types or removing anything. I believe that the new operators and functions have been present long enough now that introducing a deprecation is acceptable. Issues of getting rid of the old synonyms, replacing `ConduitM` with `Conduit`, or playing with `Void` vs `()` vs free variables are (intentionally) not addressed here.