### PR TITLE
Add unfoldEither and unfoldEitherM functions

### DIFF
--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.2.11
+
+* Add `unfoldEither` and `unfoldEitherM` to `Data.Conduit.List`
+
 ## 1.2.10
 
 * Add `PrimMonad` instances for `ConduitM` and `Pipe`

--- a/conduit/Data/Conduit/Internal/List/Stream.hs
+++ b/conduit/Data/Conduit/Internal/List/Stream.hs
@@ -23,6 +23,19 @@ unfoldS f s0 _ =
             Just (x, s') -> Emit s' x
 {-# INLINE unfoldS #-}
 
+unfoldEitherS :: Monad m
+              => (b -> Either r (a, b))
+              -> b
+              -> StreamConduitM i a m r
+unfoldEitherS f s0 _ =
+    Stream step (return s0)
+  where
+    step s = return $
+        case f s of
+            Left r        -> Stop r
+            Right (x, s') -> Emit s' x
+{-# INLINE unfoldEitherS #-}
+
 unfoldMS :: Monad m
          => (b -> m (Maybe (a, b)))
          -> b
@@ -37,6 +50,19 @@ unfoldMS f s0 _ =
             Just (x, s') -> Emit s' x
 {-# INLINE unfoldMS #-}
 
+unfoldEitherMS :: Monad m
+         => (b -> m (Either r (a, b)))
+         -> b
+         -> StreamConduitM i a m r
+unfoldEitherMS f s0 _ =
+    Stream step (return s0)
+  where
+    step s = do
+        ms' <- f s
+        return $ case ms' of
+            Left r        -> Stop r
+            Right (x, s') -> Emit s' x
+{-# INLINE unfoldEitherMS #-}
 sourceListS :: Monad m => [a] -> StreamProducer m a
 sourceListS xs0 _ =
     Stream (return . step) (return xs0)

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -1,5 +1,5 @@
 Name:                conduit
-Version:             1.2.10
+Version:             1.2.11
 Synopsis:            Streaming data processing library.
 description:
     `conduit` is a solution to the streaming data problem, allowing for production,


### PR DESCRIPTION
This provides the ability to produce a Producer-like Conduit that has
a return value.

Not sure if it's worth defining a new type alias to make the `forall i` explicit rather than implicit.

I have a use case for this where I am converting a streaming source from another library to a Conduit and I would like to keep the return value rather than just discarding it.