### PR TITLE
Speed up sinkHandle by not flushing after output

### DIFF
--- a/conduit-extra/ChangeLog.md
+++ b/conduit-extra/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.1.17
+
+* Speed up `sinkHandle` by not flushing after every output operation.
+  [#322](https://github.com/snoyberg/conduit/issues/322)
+
 ## 1.1.16
 
 * Add `Data.Conduit.Foldl` adapter module for the `foldl`

--- a/conduit-extra/Data/Conduit/Binary.hs
+++ b/conduit-extra/Data/Conduit/Binary.hs
@@ -167,9 +167,7 @@ sourceIOHandle alloc = bracketP alloc IO.hClose sourceHandle
 sinkHandle :: MonadIO m
            => IO.Handle
            -> Consumer S.ByteString m ()
-sinkHandle h = awaitForever $ \bs -> liftIO $ do
-    S.hPut h bs
-    IO.hFlush h
+sinkHandle h = awaitForever (liftIO . S.hPut h)
 
 -- | An alternative to 'sinkHandle'.
 -- Instead of taking a pre-opened 'IO.Handle', it takes an action that opens


### PR DESCRIPTION
The previous behaviour could easily lead to severe performance
degradation.

fixes #322

NOTE: In the `ChangeLog`, I listed this change for version `1.1.17` (which will presumably be the next version), but I don't know the plans for release.