### PR TITLE
Fix pass in ConduitM MonadWriter instance

### DIFF
--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.2.12.1
+
+* Fix `pass` in `ConduitM` `MonadWriter` instance
+
 ## 1.2.12
 
 * Add `exceptC`, `runExceptC` and `catchExceptC` to `Data.Conduit.Lift`

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -1,5 +1,5 @@
 Name:                conduit
-Version:             1.2.12
+Version:             1.2.12.1
 Synopsis:            Streaming data processing library.
 description:
     `conduit` is a solution to the streaming data problem, allowing for production,

--- a/conduit/test/main.hs
+++ b/conduit/test/main.hs
@@ -27,6 +27,7 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Writer (execWriter, tell, runWriterT)
 import Control.Monad.Trans.State (evalStateT, get, put, modify)
 import Control.Monad.Trans.Maybe (MaybeT (..))
+import qualified Control.Monad.Writer as W
 import Control.Applicative (pure, (<$>), (<*>))
 import qualified Control.Monad.Catch as Catch
 import Data.Functor.Identity (Identity,runIdentity)
@@ -876,6 +877,12 @@ main = hspec $ do
                     C.yield 3
                     lift $ return ()
             (src C.$$ CL.consume) `shouldBe` Right [1, 2, 4 :: Int]
+        describe "WriterT" $
+            it "pass" $
+                let writer = W.pass $ do
+                    W.tell [1 :: Int]
+                    pure ((), (2:))
+                in execWriter (C.runConduit writer) `shouldBe` [2, 1]
 
     describe "finalizers" $ do
         it "promptness" $ do


### PR DESCRIPTION
Previous implementation was equivalent to `fmap fst`, which is
probably not the intended behavior.

As an example, this

```haskell
execWriter $ runConduit $ pass $ tell [1] >> pure ((), (2:))
```

previously evaluated to `[1]`, and now evaluates to `[2,1]`.