### PR TITLE
Remove parameter to ResIO type alias

### DIFF
--- a/resourcet/Control/Monad/Trans/Resource/Internal.hs
+++ b/resourcet/Control/Monad/Trans/Resource/Internal.hs
@@ -112,7 +112,7 @@ data ReleaseMap =
   | ReleaseMapClosed
 
 -- | Convenient alias for @ResourceT IO@.
-type ResIO a = ResourceT IO a
+type ResIO = ResourceT IO
 
 
 instance MonadCont m => MonadCont (ResourceT m) where


### PR DESCRIPTION
This allows the use of ResIO as an argument to some other Monad Transformer.

eg.
ReaderT Int ResIO x