### PR TITLE
Add Handle sinks with buffering control, define more Process stdin instances

### DIFF
--- a/conduit-extra/ChangeLog.md
+++ b/conduit-extra/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.2.2
+
+* `sinkHandleBuilder`, `sinkHandleFlush`, `BuilderInput`, and `FlushInput`
+  [#336](https://github.com/snoyberg/conduit/pull/336)
+
 ## 1.2.1
 
 * `Data.Conduit.Process.Typed`

--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -1,5 +1,5 @@
 Name:                conduit-extra
-Version:             1.2.1
+Version:             1.2.2
 Synopsis:            Batteries included conduit: adapters for common libraries.
 Description:
     The conduit package itself maintains relative small dependencies. The purpose of this package is to collect commonly used utility functions wrapping other library dependencies, without depending on heavier-weight dependencies. The basic idea is that this package should only depend on haskell-platform packages and conduit.


### PR DESCRIPTION
Re: #334, upon more consideration I copied your (@snoyberg) code, just added comments and instances. Not sure if this need mentioning in the docs (PROCESS.md), as I now realize that this [expect][1]-like usage is really uncommon case for conduit.

[1]: https://linux.die.net/man/1/expect