### PR TITLE
Add Semigroup instances for Pipe and ConduitM

### DIFF
--- a/conduit/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/Data/Conduit/Internal/Conduit.hs
@@ -102,6 +102,7 @@ import Control.Monad.Base (MonadBase (liftBase))
 import Control.Monad.Primitive (PrimMonad, PrimState, primitive)
 import Data.Void (Void, absurd)
 import Data.Monoid (Monoid (mappend, mempty))
+import Data.Semigroup (Semigroup ((<>)))
 import Control.Monad.Trans.Resource
 import qualified Data.IORef as I
 import Control.Monad.Morph (MFunctor (..))
@@ -251,11 +252,17 @@ instance MonadResource m => MonadResource (ConduitM i o m) where
     liftResourceT = lift . liftResourceT
     {-# INLINE liftResourceT #-}
 
+instance Monad m => Semigroup (ConduitM i o m ()) where
+    (<>) = (>>)
+    {-# INLINE (<>) #-}
+
 instance Monad m => Monoid (ConduitM i o m ()) where
     mempty = return ()
     {-# INLINE mempty #-}
-    mappend = (>>)
+#if !(MIN_VERSION_base(4,11,0))
+    mappend = (<>)
     {-# INLINE mappend #-}
+#endif
 
 instance PrimMonad m => PrimMonad (ConduitM i o m) where
   type PrimState (ConduitM i o m) = PrimState m

--- a/conduit/Data/Conduit/Internal/Pipe.hs
+++ b/conduit/Data/Conduit/Internal/Pipe.hs
@@ -59,6 +59,7 @@ import Control.Monad.Base (MonadBase (liftBase))
 import Control.Monad.Primitive (PrimMonad, PrimState, primitive)
 import Data.Void (Void, absurd)
 import Data.Monoid (Monoid (mappend, mempty))
+import Data.Semigroup (Semigroup ((<>)))
 import Control.Monad.Trans.Resource
 import qualified GHC.Exts
 import Control.Monad.Morph (MFunctor (..))
@@ -151,11 +152,17 @@ instance Catch.MonadCatch m => Catch.MonadCatch (Pipe l i o u m) where
         go (HaveOutput p c o) = HaveOutput (go p) c o
     {-# INLINE catch #-}
 
+instance Monad m => Semigroup (Pipe l i o u m ()) where
+    (<>) = (>>)
+    {-# INLINE (<>) #-}
+
 instance Monad m => Monoid (Pipe l i o u m ()) where
     mempty = return ()
     {-# INLINE mempty #-}
-    mappend = (>>)
+#if !(MIN_VERSION_base(4,11,0))
+    mappend = (<>)
     {-# INLINE mappend #-}
+#endif
 
 instance PrimMonad m => PrimMonad (Pipe l i o u m) where
   type PrimState (Pipe l i o u m) = PrimState m

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -37,6 +37,7 @@ Library
                      , resourcet                >= 1.1          && < 1.2
                      , exceptions               >= 0.6
                      , lifted-base              >= 0.1
+                     , semigroups               >= 0.18
                      , transformers-base        >= 0.4.1        && < 0.5
                      , transformers             >= 0.2.2
                      , transformers-compat      >= 0.3
@@ -60,6 +61,7 @@ test-suite test
                    , base
                    , hspec >= 1.3
                    , QuickCheck >= 2.7
+                   , semigroups >= 0.18
                    , transformers
                    , mtl
                    , resourcet

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -37,7 +37,7 @@ Library
                      , resourcet                >= 1.1          && < 1.2
                      , exceptions               >= 0.6
                      , lifted-base              >= 0.1
-                     , semigroups               >= 0.18
+                     , semigroups               >= 0.16
                      , transformers-base        >= 0.4.1        && < 0.5
                      , transformers             >= 0.2.2
                      , transformers-compat      >= 0.3
@@ -61,7 +61,7 @@ test-suite test
                    , base
                    , hspec >= 1.3
                    , QuickCheck >= 2.7
-                   , semigroups >= 0.18
+                   , semigroups >= 0.16
                    , transformers
                    , mtl
                    , resourcet

--- a/conduit/test/Data/Conduit/StreamSpec.hs
+++ b/conduit/test/Data/Conduit/StreamSpec.hs
@@ -19,6 +19,7 @@ import           Data.Function (on)
 import qualified Data.List
 import qualified Data.Maybe
 import           Data.Monoid (Monoid(..))
+import           Data.Semigroup (Semigroup(..))
 import           Prelude
     ((.), ($), (>>=), (=<<), return, (==), Int, id, Maybe(..), Monad,
      Eq, Show, String, Functor, fst, snd)
@@ -502,9 +503,14 @@ evalStream (Stream step s0) = go =<< s0
 newtype Sum a = Sum a
   deriving (Eq, Show, Arbitrary)
 
+instance Prelude.Num a => Semigroup (Sum a) where
+  Sum x <> Sum y = Sum $ x Prelude.+ y
+
 instance Prelude.Num a => Monoid (Sum a) where
   mempty = Sum 0
-  mappend (Sum x) (Sum y) = Sum $ x Prelude.+ y
+#if !(MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+#endif
 
 preventFusion :: a -> a
 preventFusion = id


### PR DESCRIPTION
Currently, `conduit-1.2.12.1` fails to build on GHC 8.4.1 since `Semigroup` has become a superclass of `Monoid`, and `Pipe` and `ConduitM` lack `Semigroup` instances. This fixes the issue.

I opted to avoid some CPP by depending on the `semigroups` package to provide the `Semigroup` class on GHC 7.10 and older (before `Semigroup` was added to `base`). If you'd prefer to avoid incurring an extra dependency, I could alternatively remove the `semigroups` dependency and only define the `Semigroup` instances on `base-4.9` or later (at the cost of some CPP).
  