### PR TITLE
Marked resourcet as Trustworthy.

### DIFF
--- a/resourcet/Control/Monad/Trans/Resource.hs
+++ b/resourcet/Control/Monad/Trans/Resource.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE Trustworthy #-}
 -- | Allocate resources which are guaranteed to be released.
 --
 -- For more information, see <https://www.fpcomplete.com/user/snoyberg/library-documentation/resourcet>.

--- a/resourcet/Control/Monad/Trans/Resource/Internal.hs
+++ b/resourcet/Control/Monad/Trans/Resource/Internal.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE Trustworthy #-}
 
 module Control.Monad.Trans.Resource.Internal(
     InvalidAccess(..)

--- a/resourcet/Data/Acquire.hs
+++ b/resourcet/Data/Acquire.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE Trustworthy #-}
 -- | This was previously known as the Resource monad. However, that term is
 -- confusing next to the ResourceT transformer, so it has been renamed.
 

--- a/resourcet/Data/Acquire/Internal.hs
+++ b/resourcet/Data/Acquire/Internal.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE Trustworthy #-}
 module Data.Acquire.Internal
     ( Acquire (..)
     , Allocated (..)

--- a/resourcet/UnliftIO/Resource.hs
+++ b/resourcet/UnliftIO/Resource.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Trustworthy #-}
 -- | Unlifted "Control.Monad.Trans.Resource".
 --
 -- @since 1.1.10

--- a/resourcet/resourcet.cabal
+++ b/resourcet/resourcet.cabal
@@ -25,7 +25,7 @@ Library
                      , exceptions               (== 0.8.* || == 0.10.*)
                      , unliftio-core
                      , primitive
-  ghc-options:     -Wall
+  ghc-options:     -Wall -fno-warn-trustworthy-safe
 
 test-suite test
     hs-source-dirs: test


### PR DESCRIPTION
In order to be imported from Safe Haskell modules, resourcet needs to be at
least deemed "Trustworthy". In its current state, most modules could be marked
as "Safe", except for resourcet/Control/Monad/Trans/Resource/Internal.hs, which
relies on Control.Monad.Primitive, which is itself not safe.

Instead of trying to make everything "Safe", this patch only marks resourcet as
"Trustworthy", which puts no restriction upon what it can do or import, and
should therefore be a completely harmless change. It only causes GHC to emit a
warning, since most of the files marked as "Trustworhty" are actually deemed
"Safe" by the compiler, which is why this patch also adds
"-fno-warn-trustworthy-safe" to the compilation flags.

Safe Haskell documentation:
https://downloads.haskell.org/~ghc/8.2.2/docs/html/users_guide/safe_haskell.html

Discussion on this change:
https://github.com/snoyberg/conduit/issues/371