### PR TITLE
Used System.FilePath's (</>) operator to fix tests.

### DIFF
--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -85,6 +85,7 @@ test-suite test
                    , transformers
                    , transformers-base
                    , directory
+                   , filepath
     ghc-options:     -Wall
     if os(windows)
         cpp-options: -DWINDOWS

--- a/conduit-extra/test/Data/Conduit/FilesystemSpec.hs
+++ b/conduit-extra/test/Data/Conduit/FilesystemSpec.hs
@@ -5,33 +5,34 @@ import Data.Conduit
 import qualified Data.Conduit.List as CL
 import Data.Conduit.Filesystem
 import Data.List (sort, isSuffixOf)
+import System.FilePath ((</>))
 
 spec :: Spec
 spec = describe "Data.Conduit.Filesystem" $ do
     it "sourceDirectory" $ do
         res <- runConduitRes
-             $ sourceDirectory "test/filesystem"
+             $ sourceDirectory ("test" </> "filesystem")
             .| CL.filter (not . (".swp" `isSuffixOf`))
             .| CL.consume
         sort res `shouldBe`
-            [ "test/filesystem/bar.txt"
-            , "test/filesystem/baz.txt"
-            , "test/filesystem/bin"
-            , "test/filesystem/foo.txt"
+            [ "test" </> "filesystem" </> "bar.txt"
+            , "test" </> "filesystem" </> "baz.txt"
+            , "test" </> "filesystem" </> "bin"
+            , "test" </> "filesystem" </> "foo.txt"
             ]
     it "sourceDirectoryDeep" $ do
         res1 <- runConduitRes
-              $ sourceDirectoryDeep False "test/filesystem"
+              $ sourceDirectoryDeep False ("test" </> "filesystem")
              .| CL.filter (not . (".swp" `isSuffixOf`))
              .| CL.consume
         res2 <- runConduitRes
-              $ sourceDirectoryDeep True "test/filesystem"
+              $ sourceDirectoryDeep True ("test" </> "filesystem")
              .| CL.filter (not . (".swp" `isSuffixOf`))
              .| CL.consume
         sort res1 `shouldBe`
-            [ "test/filesystem/bar.txt"
-            , "test/filesystem/baz.txt"
-            , "test/filesystem/bin/bin.txt"
-            , "test/filesystem/foo.txt"
+            [ "test" </> "filesystem" </> "bar.txt"
+            , "test" </> "filesystem" </> "baz.txt"
+            , "test" </> "filesystem" </> "bin" </> "bin.txt"
+            , "test" </> "filesystem" </> "foo.txt"
             ]
         sort res1 `shouldBe` sort res2

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -58,7 +58,6 @@ Library
 
   if os(windows)
     build-depends:     Win32
-                     , filepath
     other-modules:     System.Win32File
     cpp-options:       -DWINDOWS
   else
@@ -96,6 +95,9 @@ test-suite conduit-test
                    , filepath
                    , unliftio >= 0.2.4.0
     ghc-options:     -Wall
+
+  if os(windows)
+    cpp-options:     -DWINDOWS
 
 --test-suite doctests
 --    hs-source-dirs: test

--- a/conduit/test/Spec.hs
+++ b/conduit/test/Spec.hs
@@ -11,7 +11,7 @@ import Data.Maybe (listToMaybe)
 import Data.Conduit.Combinators (slidingWindow, chunksOfE, chunksOfExactlyE)
 import Data.List (intersperse, sort, find, mapAccumL)
 import Safe (tailSafe)
-import System.FilePath (takeExtension)
+import System.FilePath (takeExtension, (</>))
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import qualified Data.Text as T
@@ -134,12 +134,12 @@ spec = do
         res <- runConduitRes
              $ sourceDirectory "test" .| filterC (not . hasExtension' ".swp") .| sinkList
         sort res `shouldBe`
-          [ "test/Data"
-          , "test/Spec.hs"
-          , "test/StreamSpec.hs"
-          , "test/doctests.hs"
-          , "test/main.hs"
-          , "test/subdir"
+          [ "test" </> "Data"
+          , "test" </> "Spec.hs"
+          , "test" </> "StreamSpec.hs"
+          , "test" </> "doctests.hs"
+          , "test" </> "main.hs"
+          , "test" </> "subdir"
           ]
     it "sourceDirectoryDeep" $ do
         res1 <- runConduitRes
@@ -147,13 +147,13 @@ spec = do
         res2 <- runConduitRes
               $ sourceDirectoryDeep True "test" .| filterC (not . hasExtension' ".swp") .| sinkList
         sort res1 `shouldBe`
-          [ "test/Data/Conduit/Extra/ZipConduitSpec.hs"
-          , "test/Data/Conduit/StreamSpec.hs"
-          , "test/Spec.hs"
-          , "test/StreamSpec.hs"
-          , "test/doctests.hs"
-          , "test/main.hs"
-          , "test/subdir/dummyfile.txt"
+          [ "test" </> "Data" </> "Conduit" </> "Extra" </> "ZipConduitSpec.hs"
+          , "test" </> "Data" </> "Conduit" </> "StreamSpec.hs"
+          , "test" </> "Spec.hs"
+          , "test" </> "StreamSpec.hs"
+          , "test" </> "doctests.hs"
+          , "test" </> "main.hs"
+          , "test" </> "subdir" </> "dummyfile.txt"
           ]
         sort res1 `shouldBe` sort res2
     prop "drop" $ \(T.pack -> input) count ->


### PR DESCRIPTION
Continuous integration was failing on AppVeyor due to the system path separator
not being the one hardcoded in the tests.