### PR TITLE
network-conduit-tls.cabal: Drop SSL3 from supported versions

### DIFF
--- a/network-conduit-tls/ChangeLog.md
+++ b/network-conduit-tls/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+* Use the recommended SSL versions from TLS
+
 ## 1.3.1
 
 * Use the default ciphersuite from TLS

--- a/network-conduit-tls/Data/Conduit/Network/TLS.hs
+++ b/network-conduit-tls/Data/Conduit/Network/TLS.hs
@@ -131,7 +131,6 @@ serverHandshake socket creds = do
         { TLS.serverWantClientCert = False
         , TLS.serverSupported = def
             { TLS.supportedCiphers = TLSExtra.ciphersuite_default
-            , TLS.supportedVersions = [TLS.SSL3,TLS.TLS10,TLS.TLS11,TLS.TLS12]
             }
         , TLS.serverShared = def
             { TLS.sharedCredentials = creds

--- a/network-conduit-tls/network-conduit-tls.cabal
+++ b/network-conduit-tls/network-conduit-tls.cabal
@@ -1,5 +1,5 @@
 name:                network-conduit-tls
-version:             1.3.1
+version:             1.3.2
 synopsis:            Create TLS-aware network code with conduits
 description:         Uses the tls package for a pure-Haskell implementation.
 homepage:            https://github.com/snoyberg/conduit


### PR DESCRIPTION
SSL3 is vulnerable to the Poodle (Padding Oracle On Downgraded Legacy
Encryption) attack. See CVE-2014-3566.

Also bump cabal version and add a ChangeLog entry.