### PR TITLE
Added MonadBase instance for ResourceT.

### DIFF
--- a/resourcet/Control/Monad/Trans/Resource/Internal.hs
+++ b/resourcet/Control/Monad/Trans/Resource/Internal.hs
@@ -54,6 +54,7 @@ import qualified Control.Monad.Trans.Writer.Strict as Strict ( WriterT )
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Primitive (PrimMonad (..))
 import qualified Control.Exception as E
+import qualified Control.Monad.Base as B
 
 -- FIXME Do we want to only support MonadThrow?
 import Control.Monad.Catch (MonadThrow (..), MonadCatch (..), MonadMask (..))
@@ -252,6 +253,9 @@ instance MonadUnliftIO m => MonadUnliftIO (ResourceT m) where
   askUnliftIO = ResourceT $ \r ->
                 withUnliftIO $ \u ->
                 return (UnliftIO (unliftIO u . flip unResourceT r))
+
+instance (B.MonadBase b m) => B.MonadBase b (ResourceT m) where
+    liftBase = lift . B.liftBase
 
 #define GO(T) instance (MonadResource m) => MonadResource (T m) where liftResourceT = lift . liftResourceT
 #define GOX(X, T) instance (X, MonadResource m) => MonadResource (T m) where liftResourceT = lift . liftResourceT

--- a/resourcet/resourcet.cabal
+++ b/resourcet/resourcet.cabal
@@ -21,6 +21,7 @@ Library
   Build-depends:       base                     >= 4.9          && < 5
                      , containers
                      , transformers             >= 0.4
+                     , transformers-base        >= 0.4.4
                      , mtl                      >= 2.0          && < 2.3
                      , exceptions               (== 0.8.* || == 0.10.*)
                      , unliftio-core


### PR DESCRIPTION
My [previous attempt](https://github.com/snoyberg/conduit/pull/372) was to try to make ResourceT compatible with Safe Haskell, so that I could add that instance in Control.Monad.Base. However, as Control.Monad.Base's maintainer [pointed out](https://github.com/mvv/transformers-base/issues/16), it makes more sense to simply add that instance in ResourceT.

I don't know why I didn't think of that in the first place. ^^'