### PR TITLE
haddock: '.|'. looks very similar to '.|.'

### DIFF
--- a/conduit/src/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/src/Data/Conduit/Internal/Conduit.hs
@@ -714,7 +714,7 @@ connect :: Monad m
         -> m r
 connect = ($$)
 
--- | Named function synonym for '.|'.
+-- | Named function synonym for '.|'
 --
 -- Equivalent to '.|' and '=$='. However, the latter is
 -- deprecated and will be removed in a future version.


### PR DESCRIPTION
Trivial haddoc fix, the docs for `fuse` has a trailing period, and `'.|'.` looks very simiar to `'.|.'`