### PR TITLE
Switch `gzip` to use zlib's special value of `-1` for compression level

### DIFF
--- a/conduit-extra/ChangeLog.md
+++ b/conduit-extra/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+* Switched `gzip` to use zlib's default compression level.
+
 ## 1.3.0
 
 * Switch over to unliftio

--- a/conduit-extra/Data/Conduit/Zlib.hs
+++ b/conduit-extra/Data/Conduit/Zlib.hs
@@ -26,7 +26,7 @@ import Data.Function (fix)
 
 -- | Gzip compression with default parameters.
 gzip :: (MonadThrow m, PrimMonad m) => ConduitT ByteString ByteString m ()
-gzip = compress 1 (WindowBits 31)
+gzip = compress (-1) (WindowBits 31)
 
 -- | Gzip decompression with default parameters.
 ungzip :: (PrimMonad m, MonadThrow m) => ConduitT ByteString ByteString m ()

--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -1,5 +1,5 @@
 Name:                conduit-extra
-Version:             1.3.0
+Version:             1.3.1
 Synopsis:            Batteries included conduit: adapters for common libraries.
 Description:
     The conduit package itself maintains relative small dependencies. The purpose of this package is to collect commonly used utility functions wrapping other library dependencies, without depending on heavier-weight dependencies. The basic idea is that this package should only depend on haskell-platform packages and conduit.


### PR DESCRIPTION
By using special value `-1` we let `zlib` know to use default compression level. It is denoted by `Z_DEFAULT_COMPRESSION = -1` in zlib and is currently equivalent to level `6`:

> Z_DEFAULT_COMPRESSION requests a default compromise between speed and compression (currently equivalent to level 6).