### PR TITLE
Enable nix users to build using e.g. stack --nix build

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -5,3 +5,5 @@ packages:
 - conduit-extra
 - network-conduit-tls
 - resourcet
+nix:
+  packages: [zlib]


### PR DESCRIPTION
Should not affect non-nix users.