### PR TITLE
Use lower-case imports (better for cross-compilation)

### DIFF
--- a/conduit/src/System/Win32File.hsc
+++ b/conduit/src/System/Win32File.hsc
@@ -31,8 +31,8 @@ import Data.ByteString.Lazy.Internal (defaultChunkSize)
 
 
 #include <fcntl.h>
-#include <Share.h>
-#include <SYS/Stat.h>
+#include <share.h>
+#include <sys/stat.h>
 #include <errno.h>
 
 newtype OFlag = OFlag CInt


### PR DESCRIPTION
In an adventure of getting one of my real-world Haskell programs to cross-compile for Windows on Linux, [`conduit` failed to build](https://github.com/input-output-hk/haskell.nix/issues/84#issuecomment-471002412). Turns out I can fix it by lower-casing the imports. I am not sure if this is the proper fix, or if some tooling should be more liberal here … but it works.