### PR TITLE
Add mapAsync to map a batch of actions asynchronously

### DIFF
--- a/conduit-extra/Data/Conduit/Async.hs
+++ b/conduit-extra/Data/Conduit/Async.hs
@@ -1,0 +1,16 @@
+-- |
+-- Simple conduits to do async operations
+module Data.Conduit.Binary
+    (
+      mapAsyncIO
+    ) where
+
+import Conduit
+import qualified Data.Conduit.List as CL
+import Control.Concurrent.Async (mapConcurrently)
+
+-- | Map `a` asynchronously to `b` using batches of at most `n` elements using `mapConcurrently`
+mapAsync :: Int -> (a -> IO b) -> ConduitT a b IO ()
+mapAsync n op = CL.chunksOf n .| mapAsynced .| CL.concat
+    where
+        mapAsynced = mapMC (mapConcurrently op)

--- a/conduit-extra/Data/Conduit/Async.hs
+++ b/conduit-extra/Data/Conduit/Async.hs
@@ -6,16 +6,33 @@ module Data.Conduit.Async
     ) where
 
 import Conduit
--- import qualified Data.Conduit.List as CL
 import Control.Concurrent.Async (async, wait)
 
--- | Map `a` asynchronously to `b` using batches of at most `n` elements using `mapConcurrently`
+-- | Yield the given value only after awaiting a value from upstream
+delayOneOf :: o -> ConduitT o o IO ()
+delayOneOf v = do
+    a <- await
+    case a of
+        Nothing -> do
+            yield v
+            return ()
+        Just b -> do
+            yield v
+            delayOneOf b
+-- | Delay a value by one yield acting as a buffer
+delayOne :: ConduitT o o IO ()
+delayOne = do
+    a <- await
+    case a of
+        Nothing -> return ()
+        Just b -> delayOneOf b
+
+-- | Map `a` asynchronously to `b` using `op` and approximately `n` threads
 -- The idea behind this approach is that it will set up a conduit which starts the async process,
--- passes along the handle `n` times and then awaits for the result.
+-- passes along the handle `n` times using a delayed conduit and then awaits for the result.
 mapAsync :: Int -> (a -> IO b) -> ConduitT a b IO ()
 mapAsync n op = startAsync .| queue .| joinAsync
     where
-        nop = awaitForever yield
-        startAsync = mapMC (\x -> async (op x))
-        queue = foldl (.|) nop (replicate n nop)
+        startAsync = mapMC (async . op)
+        queue = foldl (.|) delayOne (replicate (n - 1) delayOne)
         joinAsync = mapMC wait

--- a/conduit-extra/Data/Conduit/Async.hs
+++ b/conduit-extra/Data/Conduit/Async.hs
@@ -1,16 +1,21 @@
 -- |
 -- Simple conduits to do async operations
-module Data.Conduit.Binary
+module Data.Conduit.Async
     (
-      mapAsyncIO
+      mapAsync
     ) where
 
 import Conduit
-import qualified Data.Conduit.List as CL
-import Control.Concurrent.Async (mapConcurrently)
+-- import qualified Data.Conduit.List as CL
+import Control.Concurrent.Async (async, wait)
 
 -- | Map `a` asynchronously to `b` using batches of at most `n` elements using `mapConcurrently`
+-- The idea behind this approach is that it will set up a conduit which starts the async process,
+-- passes along the handle `n` times and then awaits for the result.
 mapAsync :: Int -> (a -> IO b) -> ConduitT a b IO ()
-mapAsync n op = CL.chunksOf n .| mapAsynced .| CL.concat
+mapAsync n op = startAsync .| queue .| joinAsync
     where
-        mapAsynced = mapMC (mapConcurrently op)
+        nop = awaitForever yield
+        startAsync = mapMC (\x -> async (op x))
+        queue = foldl (.|) nop (replicate n nop)
+        joinAsync = mapMC wait

--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -20,6 +20,7 @@ extra-source-files:
 
 Library
   Exposed-modules:     Data.Conduit.Attoparsec
+                       Data.Conduit.Async
                        Data.Conduit.Binary
                        Data.Conduit.ByteString.Builder
                        Data.Conduit.Filesystem
@@ -90,6 +91,7 @@ test-suite test
     if os(windows)
         cpp-options: -DWINDOWS
     other-modules:   Data.Conduit.AttoparsecSpec
+                     Data.Conduit.AsyncSpec
                      Data.Conduit.BinarySpec
                      Data.Conduit.ByteString.BuilderSpec
                      Data.Conduit.ExtraSpec

--- a/conduit-extra/test/Data/Conduit/AsyncSpec.hs
+++ b/conduit-extra/test/Data/Conduit/AsyncSpec.hs
@@ -12,16 +12,11 @@ import qualified Data.Conduit.Text as CT
 import Control.Concurrent
 
 spec :: Spec
-spec = describe "Data.Conduit.Async" $ do
-    it "prints" $ do
-        let source = CL.sourceList ["anna", "banana", "cuckoo"]
-            printAndPassthrough s = do
-                putStrLn $ "Starting " ++ s
-                threadDelay 10000000
-                putStrLn $ "Done " ++ s
-                return s
-        res <- runConduit $ source .| mapAsync 2 printAndPassthrough .| CL.consume
-        res `shouldBe` ["anna", "banana", "cuckoo"]
+spec = describe "Data.Conduit.Async" $
+    it "maintains order on mapAsync" $ do
+        let source = CL.sourceList "abcdefg"
+        res <- runConduit $ source .| mapAsync 3 return .| CL.consume
+        res `shouldBe` "abcdefg"
 
 main :: IO ()
 main = hspec spec

--- a/conduit-extra/test/Data/Conduit/AsyncSpec.hs
+++ b/conduit-extra/test/Data/Conduit/AsyncSpec.hs
@@ -1,0 +1,27 @@
+module Data.Conduit.AsyncSpec where
+
+import Data.Conduit
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Data.Conduit.Async
+import qualified Data.Conduit.List as CL
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.ByteString as S
+import qualified Data.Conduit.Text as CT
+import Control.Concurrent
+
+spec :: Spec
+spec = describe "Data.Conduit.Async" $ do
+    it "prints" $ do
+        let source = CL.sourceList ["anna", "banana", "cuckoo"]
+            printAndPassthrough s = do
+                putStrLn $ "Starting " ++ s
+                threadDelay 10000000
+                putStrLn $ "Done " ++ s
+                return s
+        res <- runConduit $ source .| mapAsync 2 printAndPassthrough .| CL.consume
+        res `shouldBe` ["anna", "banana", "cuckoo"]
+
+main :: IO ()
+main = hspec spec


### PR DESCRIPTION
Having used Akka streams in Scala, I was expecting something like `mapAsync`:
https://doc.akka.io/docs/akka/current/stream/operators/index.html#asynchronous-operators

But I could not get http://hackage.haskell.org/package/conduit-concurrent-map-0.1.1/docs/Data-Conduit-ConcurrentMap.html and could not find any such method in conduit-extra.

The solution below is trivial, but I would like to see methods like this in conduit-extra.

Is there interest to work towards adding utility methods like these to conduit-extra? If so, I would love to hear comments to move forward on this.