### PR TITLE
chunksOf: eagerly emit groups

### DIFF
--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for conduit
 
+## 1.3.1.2
+
+* More eagerly emit groups in `chunksOf` [#427](https://github.com/snoyberg/conduit/pull/427)
+
 ## 1.3.1.1
 
 * Use lower-case imports (better for cross-compilation) [#408](https://github.com/snoyberg/conduit/pull/408)

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -1,5 +1,5 @@
 Name:                conduit
-Version:             1.3.1.1
+Version:             1.3.1.2
 Synopsis:            Streaming data processing library.
 description:
     `conduit` is a solution to the streaming data problem, allowing for production,

--- a/conduit/src/Data/Conduit/List.hs
+++ b/conduit/src/Data/Conduit/List.hs
@@ -88,6 +88,9 @@ import Prelude
     , maybe
     , (<=)
     , (>)
+    , error
+    , (++)
+    , show
     )
 import Data.Monoid (Monoid, mempty, mappend)
 import qualified Data.Foldable as F


### PR DESCRIPTION
Prior to this change, `chunksOf` did not emit groups as soon as it could:

```haskell
main = runConduit
  $ (yieldMany ['1', '2'] >> liftIO (print "should not print"))
  .| CL.chunksOf 2
  .| takeC 1
  .| printC
```

Prints

```
"should not print"
"12"
```

After this change, `chunksOf` will emit groups immediately when they are ready. Here's the new output:

```
"12"
```

Any tips on writing/updating tests?

Improves upon https://github.com/snoyberg/conduit/pull/296