### PR TITLE
Add Acquire based version of bracketP.

### DIFF
--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for conduit
 
+## 1.3.2
+
+* Add an Acquire based version of bracketP called bracketAcquireP [#430](https://github.com/snoyberg/conduit/pull/430)
+
 ## 1.3.1.2
 
 * More eagerly emit groups in `chunksOf` [#427](https://github.com/snoyberg/conduit/pull/427)

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -1,5 +1,5 @@
 Name:                conduit
-Version:             1.3.1.2
+Version:             1.3.2
 Synopsis:            Streaming data processing library.
 description:
     `conduit` is a solution to the streaming data problem, allowing for production,

--- a/conduit/src/Data/Conduit.hs
+++ b/conduit/src/Data/Conduit.hs
@@ -39,6 +39,7 @@ module Data.Conduit
 
       -- ** Finalization
     , bracketP
+    , bracketAcquireP
 
       -- ** Exception handling
     , catchC

--- a/conduit/src/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/src/Data/Conduit/Internal/Conduit.hs
@@ -62,8 +62,8 @@ module Data.Conduit.Internal.Conduit
     , toProducer
     , toConsumer
       -- ** Cleanup
-    , bracketAcquireP
     , bracketP
+    , bracketAcquireP
       -- ** Exceptions
     , catchC
     , handleC
@@ -101,6 +101,7 @@ import Control.Monad.State.Class(MonadState(..))
 import Control.Monad.Trans.Class (MonadTrans (lift))
 import Control.Monad.IO.Unlift (MonadIO (liftIO), MonadUnliftIO, withRunInIO)
 import Control.Monad.Primitive (PrimMonad, PrimState, primitive)
+import Data.Acquire (Acquire, allocateAcquire, mkAcquire)
 import Data.Functor.Identity (Identity, runIdentity)
 import Data.Void (Void, absurd)
 import Data.Monoid (Monoid (mappend, mempty))


### PR DESCRIPTION
I'm working with an API that only exposes Acquire directly as means of working with a resource, the current bracketP in conduit makes it kinda nasty to work with. This PR adds an alternate version of bracketP working with Acquire values.