### PR TITLE
Monadic 'mapInput'

### DIFF
--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,6 +1,6 @@
 # ChangeLog for conduit
 
-## 1.3.1.3
+## 1.3.2
 
 * Add `mapInputM` [#435](https://github.com/snoyberg/conduit/pull/435)
 

--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for conduit
 
+## 1.3.1.3
+
+* Add `mapInputM` [#435](https://github.com/snoyberg/conduit/pull/435)
+
 ## 1.3.1.2
 
 * More eagerly emit groups in `chunksOf` [#427](https://github.com/snoyberg/conduit/pull/427)

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -1,5 +1,5 @@
 Name:                conduit
-Version:             1.3.1.2
+Version:             1.3.1.3
 Synopsis:            Streaming data processing library.
 description:
     `conduit` is a solution to the streaming data problem, allowing for production,

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -1,5 +1,5 @@
 Name:                conduit
-Version:             1.3.1.3
+Version:             1.3.2
 Synopsis:            Streaming data processing library.
 description:
     `conduit` is a solution to the streaming data problem, allowing for production,

--- a/conduit/src/Data/Conduit.hs
+++ b/conduit/src/Data/Conduit.hs
@@ -57,6 +57,7 @@ module Data.Conduit
     , mapOutput
     , mapOutputMaybe
     , mapInput
+    , mapInputM
     , mergeSource
     , passthroughSink
     , sourceToList

--- a/conduit/src/Data/Conduit/Internal.hs
+++ b/conduit/src/Data/Conduit/Internal.hs
@@ -11,8 +11,9 @@ module Data.Conduit.Internal
 
 import           Data.Conduit.Internal.Conduit hiding (await,
                                                 awaitForever, bracketP,
-                                                leftover, mapInput, mapOutput,
-                                                mapOutputMaybe, transPipe,
+                                                leftover, mapInput, mapInputM,
+                                                mapOutput, mapOutputMaybe,
+                                                transPipe,
                                                 yield, yieldM)
 import           Data.Conduit.Internal.Pipe
 import           Data.Conduit.Internal.Fusion

--- a/conduit/src/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/src/Data/Conduit/Internal/Conduit.hs
@@ -991,6 +991,8 @@ mapInput f f' (ConduitT c0) = ConduitT $ \rest -> let
     in go (c0 Done)
 
 -- | Apply a monadic action to all the input values of a @ConduitT@.
+--
+-- Since 1.3.1.3
 mapInputM :: Monad m
           => (i1 -> m i2) -- ^ map initial input to new input
           -> (i2 -> m (Maybe i1)) -- ^ map new leftovers to initial leftovers

--- a/conduit/src/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/src/Data/Conduit/Internal/Conduit.hs
@@ -992,7 +992,7 @@ mapInput f f' (ConduitT c0) = ConduitT $ \rest -> let
 
 -- | Apply a monadic action to all the input values of a @ConduitT@.
 --
--- Since 1.3.1.3
+-- Since 1.3.2
 mapInputM :: Monad m
           => (i1 -> m i2) -- ^ map initial input to new input
           -> (i2 -> m (Maybe i1)) -- ^ map new leftovers to initial leftovers


### PR DESCRIPTION
This PR adds a variant of `mapInput` which allows monadic effects to execute in the conversion. This turned out to be needed in [the Mu project](https://github.com/higherkindness/mu-haskell) to convert sinks where the conversion requires working in the `IO` monad.