### PR TITLE
Don't unmask resource allocation

### DIFF
--- a/resourcet/ChangeLog.md
+++ b/resourcet/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for resourcet
 
+## 1.2.4.2
+
+* Mask exceptions in `Acquire` allocation action
+
 ## 1.2.4.1
 
 * Document risk of using `forkIO` within a `ResourceT` [#441](https://github.com/snoyberg/conduit/pull/441)

--- a/resourcet/Data/Acquire/Internal.hs
+++ b/resourcet/Data/Acquire/Internal.hs
@@ -70,8 +70,8 @@ instance MonadIO Acquire where
 mkAcquire :: IO a -- ^ acquire the resource
           -> (a -> IO ()) -- ^ free the resource
           -> Acquire a
-mkAcquire create free = Acquire $ \restore -> do
-    x <- restore create
+mkAcquire create free = Acquire $ \_ -> do
+    x <- create
     return $! Allocated x (const $ free x)
 
 -- | Same as 'mkAcquire', but the cleanup function will be informed of /how/
@@ -83,8 +83,8 @@ mkAcquireType
     :: IO a -- ^ acquire the resource
     -> (a -> ReleaseType -> IO ()) -- ^ free the resource
     -> Acquire a
-mkAcquireType create free = Acquire $ \restore -> do
-    x <- restore create
+mkAcquireType create free = Acquire $ \_ -> do
+    x <- create
     return $! Allocated x (free x)
 
 -- | Allocate the given resource and provide it to the provided function. The

--- a/resourcet/resourcet.cabal
+++ b/resourcet/resourcet.cabal
@@ -1,5 +1,5 @@
 Name:                resourcet
-Version:             1.2.4.1
+Version:             1.2.4.2
 Synopsis:            Deterministic allocation and freeing of scarce resources.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/resourcet>.
 License:             BSD3


### PR DESCRIPTION
Asynchronous exceptions shouldn't be unmasked during resource allocation. Identical problem was fixed in `ResourceT` in 687df0555641489e8cf3e5d81cef9fd5d372be01.