### PR TITLE
Remove unneeded dependency on bytestring-builder

### DIFF
--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -85,8 +85,6 @@ test-suite test
                    , transformers-base
                    , directory
                    , filepath
-    if !impl(ghc >= 7.8)
-        build-depends: bytestring-builder
     ghc-options:     -Wall
     if os(windows)
         cpp-options: -DWINDOWS
@@ -111,8 +109,6 @@ benchmark blaze
                   , gauge
                   , bytestring
                   , transformers
-    if !impl(ghc >= 7.8)
-        build-depends: bytestring-builder
     main-is:        blaze.hs
     ghc-options:    -Wall -O2 -rtsopts
 

--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -73,7 +73,6 @@ test-suite test
 
                    , async
                    , attoparsec
-                   , bytestring-builder
                    , bytestring
                    , exceptions
                    , process
@@ -86,6 +85,8 @@ test-suite test
                    , transformers-base
                    , directory
                    , filepath
+    if !impl(ghc >= 7.8)
+        build-depends: bytestring-builder
     ghc-options:     -Wall
     if os(windows)
         cpp-options: -DWINDOWS
@@ -109,8 +110,9 @@ benchmark blaze
                   , conduit-extra
                   , gauge
                   , bytestring
-                  , bytestring-builder
                   , transformers
+    if !impl(ghc >= 7.8)
+        build-depends: bytestring-builder
     main-is:        blaze.hs
     ghc-options:    -Wall -O2 -rtsopts
 


### PR DESCRIPTION
It's not needed on newer GHC.