### PR TITLE
conduit: Fix tests for GHC 9.2

### DIFF
--- a/conduit/test/main.hs
+++ b/conduit/test/main.hs
@@ -264,7 +264,7 @@ main = hspec $ do
             x <- runConduitRes $
                 CI.ConduitT
                     ((CI.unConduitT (CL.sourceList [1..10]) CI.Done
-                    CI.>+> CI.injectLeftovers ((`CI.unConduitT` CI.Done) $ CL.map (* 2))) >>=)
+                    CI.>+> CI.injectLeftovers ((\c -> c `CI.unConduitT` CI.Done) $ CL.map (* 2))) >>=)
                     .| CL.fold (+) 0
             x `shouldBe` 2 * sum [1..10 :: Int]
 
@@ -580,8 +580,8 @@ main = hspec $ do
             y <- runConduit $ CL.sourceList [1..10 :: Int] .| CL.fold (+) 0
             x `shouldBe` y
         it' "right identity" $ do
-            x <- CI.runPipe $ mapM_ CI.yield [1..10 :: Int] CI.>+> (CI.injectLeftovers $ (`CI.unConduitT` CI.Done) $ CL.fold (+) 0) CI.>+> CI.idP
-            y <- CI.runPipe $ mapM_ CI.yield [1..10 :: Int] CI.>+> (CI.injectLeftovers $ (`CI.unConduitT` CI.Done) $ CL.fold (+) 0)
+            x <- CI.runPipe $ mapM_ CI.yield [1..10 :: Int] CI.>+> (CI.injectLeftovers $ (\c -> c `CI.unConduitT` CI.Done) $ CL.fold (+) 0) CI.>+> CI.idP
+            y <- CI.runPipe $ mapM_ CI.yield [1..10 :: Int] CI.>+> (CI.injectLeftovers $ (\c -> c `CI.unConduitT` CI.Done) $ CL.fold (+) 0)
             x `shouldBe` y
 
     describe "generalizing" $ do
@@ -630,7 +630,7 @@ main = hspec $ do
     describe "injectLeftovers" $ do
         it "works" $ do
             let src = mapM_ CI.yield [1..10 :: Int]
-                conduit = CI.injectLeftovers $ (`CI.unConduitT` CI.Done) $ C.awaitForever $ \i -> do
+                conduit = CI.injectLeftovers $ (\c -> c `CI.unConduitT` CI.Done) $ C.awaitForever $ \i -> do
                     js <- CL.take 2
                     mapM_ C.leftover $ reverse js
                     C.yield i


### PR DESCRIPTION
Similar fix to #473

Tests were failing to compile with

```
test/main.hs:267:49: error:
    • Couldn't match type: forall b2.
                           (() -> CI.Pipe o5 o5 o5 () m5 b2) -> CI.Pipe o5 o5 o5 () m5 b2
                     with: (r2 -> CI.Pipe l2 i4 o4 u2 m4 r2)
                           -> CI.Pipe
                                b1
                                b1
                                Int
                                ()
                                (Control.Monad.Trans.Resource.Internal.ResourceT IO)
                                ()
      Expected: ConduitT o5 o5 m5 ()
                -> (r2 -> CI.Pipe l2 i4 o4 u2 m4 r2)
                -> CI.Pipe
                     b1
                     b1
                     Int
                     ()
                     (Control.Monad.Trans.Resource.Internal.ResourceT IO)
                     ()
        Actual: ConduitT o5 o5 m5 ()
                -> forall b.
                   (() -> CI.Pipe o5 o5 o5 () m5 b) -> CI.Pipe o5 o5 o5 () m5 b
    • In the expression: CI.unConduitT
      In the first argument of ‘($)’, namely ‘(`CI.unConduitT` CI.Done)’
      In the first argument of ‘CI.injectLeftovers’, namely
        ‘((`CI.unConduitT` CI.Done) $ CL.map (* 2))’
    |
267 |                     CI.>+> CI.injectLeftovers ((`CI.unConduitT` CI.Done) $ CL.map (* 2))) >>=)
    |
```

(etc)