### PR TITLE
Add MonadBase IO instances

### DIFF
--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -46,6 +46,7 @@ Library
   Build-depends:       base                     >= 4.12         && < 5
                      , resourcet                >= 1.2          && < 1.3
                      , transformers             >= 0.4
+                     , transformers-base
                      , mtl
                      , primitive
                      , unliftio-core
@@ -82,6 +83,7 @@ test-suite conduit-test
                    , hspec >= 1.3
                    , QuickCheck >= 2.7
                    , transformers
+                   , transformers-base
                    , mtl
                    , resourcet
                    , containers
@@ -129,6 +131,7 @@ benchmark optimize-201408
                   , deepseq
                   , containers
                   , transformers
+                  , transformers-base
                   , hspec
                   , mwc-random
                   , gauge
@@ -144,6 +147,7 @@ benchmark unfused
                   , conduit
                   , gauge
                   , transformers
+                  , transformers-base
     main-is:        unfused.hs
     ghc-options:    -Wall -O2 -rtsopts
 

--- a/conduit/src/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/src/Data/Conduit/Internal/Conduit.hs
@@ -112,6 +112,7 @@ import Data.Conduit.Internal.Pipe hiding (yield, mapOutput, leftover, yieldM, aw
 import qualified Data.Conduit.Internal.Pipe as CI
 import Control.Monad (forever)
 import Data.Traversable (Traversable (..))
+import Control.Monad.Base
 
 -- | Core datatype of the conduit package. This type represents a general
 -- component which can consume a stream of input values @i@, produce a stream
@@ -163,6 +164,9 @@ instance MonadThrow m => MonadThrow (ConduitT i o m) where
 instance MonadIO m => MonadIO (ConduitT i o m) where
     liftIO = lift . liftIO
     {-# INLINE liftIO #-}
+
+instance MonadBase IO m => MonadBase IO (ConduitT i o m) where
+  liftBase = lift . liftBase
 
 instance MonadReader r m => MonadReader r (ConduitT i o m) where
     ask = lift ask

--- a/resourcet/Control/Monad/Trans/Resource/Internal.hs
+++ b/resourcet/Control/Monad/Trans/Resource/Internal.hs
@@ -64,6 +64,7 @@ import qualified Data.IORef as I
 import Data.Typeable
 import Data.Word(Word)
 import Data.Acquire.Internal (ReleaseType (..))
+import Control.Monad.Base
 
 -- | A @Monad@ which allows for safe resource allocation. In theory, any monad
 -- transformer stack which includes a @ResourceT@ can be an instance of
@@ -255,6 +256,9 @@ instance MonadTrans ResourceT where
 
 instance MonadIO m => MonadIO (ResourceT m) where
     liftIO = lift . liftIO
+
+instance MonadBase IO m => MonadBase IO (ResourceT m) where
+  liftBase = lift . liftBase
 
 -- | @since 1.1.10
 instance MonadUnliftIO m => MonadUnliftIO (ResourceT m) where

--- a/resourcet/resourcet.cabal
+++ b/resourcet/resourcet.cabal
@@ -22,6 +22,7 @@ Library
   Build-depends:       base                     >= 4.12         && < 5
                      , containers
                      , transformers             >= 0.4
+                     , transformers-base
                      , mtl                      >= 2.0          && < 2.3
                      , exceptions               (== 0.8.* || == 0.10.*)
                      , unliftio-core >= 0.1.1.0
@@ -39,6 +40,7 @@ test-suite test
                    , exceptions
                    , hspec >= 1.3
                    , transformers
+                   , transformers-base
     ghc-options:     -Wall
 
 source-repository head


### PR DESCRIPTION
This makes it easier to interface with [`lifted-async`](https://hackage.haskell.org/package/lifted-async), [`lifted-base`](https://hackage.haskell.org/package/lifted-base), and others.

The adds a dependency on `transformers-base`, which seems pretty small (107 LOC) and stable (~3 patch releases in 4 years).