### PR TITLE
Add concurrentMap

### DIFF
--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -56,6 +56,8 @@ Library
                      , text
                      , filepath
                      , directory
+                     , containers
+                     , async
 
   if os(windows)
     build-depends:     Win32
@@ -96,6 +98,7 @@ test-suite conduit-test
                    , silently
                    , filepath
                    , unliftio >= 0.2.4.0
+                   , async
     ghc-options:     -Wall
 
   if os(windows)

--- a/conduit/src/Data/Conduit/Combinators.hs
+++ b/conduit/src/Data/Conduit/Combinators.hs
@@ -2578,11 +2578,12 @@ instance Exception InvalidConcurrencyLimitException
 --
 -- Exceptions in IO transformations propagate to the main thread, and all
 -- workers are canceled when the conduit hits an exception. Exceptions in the IO
--- transformation are held until they reaches the head of the queue and
--- execution re-enters this function after awaiting an input value or yielding
--- an output value.
+-- transformation are held until they reach the head of the queue and execution
+-- re-enters this function.
 --
--- Output values are yielded promptly.
+-- Output values are yielded promptly. That is, once an IO transformation
+-- completes, the output value will be yielded before this function awaits more
+-- input.
 --
 -- Throws 'InvalidConcurrencyLimitException' when the given concurrency is not
 -- positive.

--- a/conduit/src/Data/Conduit/Combinators/Unqualified.hs
+++ b/conduit/src/Data/Conduit/Combinators/Unqualified.hs
@@ -180,6 +180,8 @@ module Data.Conduit.Combinators.Unqualified
     , CC.mapAccumS
     , CC.peekForever
     , CC.peekForeverE
+    , CC.concurrentMap
+    , CC.InvalidConcurrencyLimitException (..)
     ) where
 
 -- BEGIN IMPORTS

--- a/conduit/test/Spec.hs
+++ b/conduit/test/Spec.hs
@@ -43,7 +43,11 @@ import Data.ByteString.Builder (byteString, toLazyByteString)
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy.Char8 as L8
 import qualified StreamSpec
-import UnliftIO.Exception (pureTry)
+import GHC.IO (catchAny)
+import Control.Exception (fromException)
+import UnliftIO.Exception (pureTry, stringException)
+import Control.Concurrent.Async (ExceptionInLinkedThread (..))
+import Control.Concurrent.MVar
 
 spec :: Spec
 spec = do
@@ -652,6 +656,44 @@ spec = do
         res1 <- runConduit $ yieldMany strs .| linesUnboundedC .| sinkList
         res2 <- runConduit $ yieldMany strs .| peekForeverE (lineC $ foldC >>= yield) .| sinkList
         res2 `shouldBe` res1
+    describe "concurrentMap" $ do
+        let boom = stringException "boom"
+        let isBoom e = maybe False (== boom) $ fromException e
+        let isLinkedBoom e = case fromException e of
+                Nothing -> False
+                Just (ExceptionInLinkedThread _ inner) -> isBoom inner
+        let block = newEmptyMVar >>= takeMVar :: IO ()
+        it "propagates exceptions" $ do
+            let go = runConduitRes $ yield () .| concurrentMap 10 (\_ -> throwM boom) .| sinkNull
+            go `shouldThrow` isLinkedBoom
+        it "rejects invalid concurrency" $ do
+            let go = runConduitRes $ yield () .| concurrentMap 0 return .| sinkNull
+            go `shouldThrow` (== InvalidConcurrencyLimitException)
+        it "uses concurrency" $ do
+            ready <- newEmptyMVar
+            let source = yield (takeMVar ready) >> yield (putMVar ready ())
+            runConduitRes $ source .| concurrentMap 10 id .| sinkNull
+            return () :: IO ()
+        it "kills all workers upon an exception in any worker" $ do
+            ready <- newEmptyMVar
+            killed <- newEmptyMVar
+            let source = do
+                    yield $ (putMVar ready () >> block) `catchAny` (\_ -> putMVar killed ())
+                    liftIO $ takeMVar ready
+                    yield $ throwM boom
+            let go = runConduitRes $ source .| concurrentMap 10 id .| sinkNull
+            go `shouldThrow` isLinkedBoom
+            takeMVar killed
+        it "kills all workers upon an exception in the conduit" $ do
+            ready <- newEmptyMVar
+            killed <- newEmptyMVar
+            let source = do
+                    yield $ (putMVar ready () >> block) `catchAny` (\_ -> putMVar killed ())
+                    liftIO $ takeMVar ready
+                    throwM boom
+            let go = runConduitRes $ source .| concurrentMap 10 id .| sinkNull
+            go `shouldThrow` isBoom
+            takeMVar killed
     StreamSpec.spec
 
 evenInt :: Int -> Bool


### PR DESCRIPTION
Adds `concurrentMap`, which spawns worker threads to process values concurrently.

This adds dependencies on `containers` and `async`. If that's unacceptable, perhaps it could be moved to conduit-extra.