### PR TITLE
conduit-extra: Add hspec-discover to build-tool-depends

### DIFF
--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -85,6 +85,7 @@ test-suite test
                    , transformers-base
                    , directory
                    , filepath
+    build-tool-depends: hspec-discover:hspec-discover
     ghc-options:     -Wall
     if os(windows)
         cpp-options: -DWINDOWS


### PR DESCRIPTION
…so the testsuite can be run with cabal.