### PR TITLE
Add unlifted version of `allocate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 dist/
+dist-newstyle/
 conduit/tmp
 conduit/tmp2
 conduit-extra/tmp

--- a/resourcet/ChangeLog.md
+++ b/resourcet/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for resourcet
 
+## 1.2.6
+
+* Add `allocateU` [#490](https://github.com/snoyberg/conduit/pull/490)
+
 ## 1.2.5
 
 * Support `transformers-0.6` / `mtl-2.3`

--- a/resourcet/UnliftIO/Resource.hs
+++ b/resourcet/UnliftIO/Resource.hs
@@ -5,6 +5,7 @@ module UnliftIO.Resource
   ( -- * UnliftIO variants
     runResourceT
   , liftResourceT
+  , allocateU
     -- * Reexports
   , module Control.Monad.Trans.Resource
   ) where
@@ -25,3 +26,14 @@ runResourceT m = withRunInIO $ \run -> Res.runResourceT $ Res.transResourceT run
 -- @since 1.1.10
 liftResourceT :: MonadIO m => ResourceT IO a -> ResourceT m a
 liftResourceT (ResourceT f) = ResourceT $ liftIO . f
+
+-- | Unlifted 'allocate'.
+--
+-- @since 1.2.6
+allocateU
+  :: (MonadUnliftIO m, MonadResource m)
+  => m a
+  -> (a -> m ())
+  -> m (ReleaseKey, a)
+allocateU alloc free = withRunInIO $ \run ->
+  run $ allocate (run alloc) (run . free)

--- a/resourcet/resourcet.cabal
+++ b/resourcet/resourcet.cabal
@@ -1,5 +1,5 @@
 Name:                resourcet
-Version:             1.2.5
+Version:             1.2.6
 Synopsis:            Deterministic allocation and freeing of scarce resources.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/resourcet>.
 License:             BSD3


### PR DESCRIPTION
Closes [#392](https://github.com/snoyberg/conduit/issues/392).

If anyone has suggestions for a better name, let me know. I avoided
`allocate'` because the tick often implies some kind of strictness.