### PR TITLE
Documentation: replace dead link with archived version

### DIFF
--- a/conduit/src/Data/Conduit/Combinators.hs
+++ b/conduit/src/Data/Conduit/Combinators.hs
@@ -2431,7 +2431,7 @@ reuseBuffer (Buffer fpbuf _ _ ope) = Buffer fpbuf p0 p0 ope
 -- Under the surface, this function uses a number of tricks to get high
 -- performance. For more information on both usage and implementation,
 -- please see:
--- <https://www.fpcomplete.com/user/snoyberg/library-documentation/vectorbuilder>
+-- <https://www.schoolofhaskell.com/user/snoyberg/library-documentation/vectorbuilder>
 --
 -- @since 1.3.0
 vectorBuilder :: (PrimMonad m, PrimMonad n, V.Vector v e, PrimState m ~ PrimState n)


### PR DESCRIPTION
The link in the documentation of `vectorBuilder` returns a 404:
https://www.fpcomplete.com/user/snoyberg/library-documentation/vectorbuilder. 

The Internet Archive though has a version available:
https://web.archive.org/web/20150919210626/https://www.fpcomplete.com/user/snoyberg/library-documentation/vectorbuilder