### PR TITLE
Remove reference to conduit-combinators

### DIFF
--- a/conduit/src/Data/Conduit/List.hs
+++ b/conduit/src/Data/Conduit/List.hs
@@ -8,9 +8,6 @@
 -- Higher-level functions to interact with the elements of a stream. Most of
 -- these are based on list functions.
 --
--- For many purposes, it's recommended to use the conduit-combinators library,
--- which provides a more complete set of functions.
---
 -- Note that these functions all deal with individual elements of a stream as a
 -- sort of \"black box\", where there is no introspection of the contained
 -- elements. Values such as @ByteString@ and @Text@ will likely need to be


### PR DESCRIPTION
I was reading the documentation and searched conduit-combinators but there it says that the library is deprecated. This comment is misleading.