### PR TITLE
Update docs to avoid use of deprecated type aliases

### DIFF
--- a/conduit/benchmarks/OldText.hs
+++ b/conduit/benchmarks/OldText.hs
@@ -77,7 +77,7 @@ instance Show Codec where
 -- | Emit each line separately
 --
 -- Since 0.4.1
-lines :: Monad m => Conduit T.Text m T.Text
+lines :: Monad m => ConduitT T.Text T.Text m ()
 lines =
     loop id
   where
@@ -107,7 +107,7 @@ lines =
 -- user input (e.g. a file upload) because we can't be sure that
 -- user input won't have extraordinarily large lines which would
 -- require large amounts of memory if consumed.
-linesBounded :: MonadThrow m => Int -> Conduit T.Text m T.Text
+linesBounded :: MonadThrow m => Int -> ConduitT T.Text T.Text m ()
 linesBounded maxLineLen =
     loop 0 id
   where
@@ -140,7 +140,7 @@ linesBounded maxLineLen =
 -- not capable of representing an input character, an exception will be thrown.
 --
 -- Since 0.3.0
-encode :: MonadThrow m => Codec -> Conduit T.Text m B.ByteString
+encode :: MonadThrow m => Codec -> ConduitT T.Text B.ByteString m ()
 encode codec = CL.mapM $ \t -> do
     let (bs, mexc) = codecEncode codec t
     maybe (return bs) (monadThrow . fst) mexc
@@ -150,7 +150,7 @@ encode codec = CL.mapM $ \t -> do
 -- not capable of decoding an input byte sequence, an exception will be thrown.
 --
 -- Since 0.3.0
-decode :: MonadThrow m => Codec -> Conduit B.ByteString m T.Text
+decode :: MonadThrow m => Codec -> ConduitT B.ByteString T.Text m ()
 decode codec =
     loop id
   where
@@ -380,7 +380,7 @@ maybeDecode (a, b) = case tryEvaluate a of
 -- Since 1.0.8
 takeWhile :: Monad m
           => (Char -> Bool)
-          -> Conduit T.Text m T.Text
+          -> ConduitT T.Text T.Text m ()
 takeWhile p =
     loop
   where
@@ -396,7 +396,7 @@ takeWhile p =
 -- Since 1.0.8
 dropWhile :: Monad m
           => (Char -> Bool)
-          -> Consumer T.Text m ()
+          -> ConduitT T.Text o m ()
 dropWhile p =
     loop
   where
@@ -410,7 +410,7 @@ dropWhile p =
 -- |
 --
 -- Since 1.0.8
-take :: Monad m => Int -> Conduit T.Text m T.Text
+take :: Monad m => Int -> ConduitT T.Text T.Text m ()
 take =
     loop
   where
@@ -427,7 +427,7 @@ take =
 -- |
 --
 -- Since 1.0.8
-drop :: Monad m => Int -> Consumer T.Text m ()
+drop :: Monad m => Int -> ConduitT T.Text o m ()
 drop =
     loop
   where
@@ -463,8 +463,8 @@ foldLines f =
 --
 -- Since 1.0.8
 withLine :: Monad m
-         => Sink T.Text m a
-         -> Consumer T.Text m (Maybe a)
+         => ConduitT T.Text Void m a
+         -> ConduitT T.Text o m (Maybe a)
 withLine consumer = toConsumer $ do
     mx <- CL.peek
     case mx of

--- a/conduit/benchmarks/benchmark.hs
+++ b/conduit/benchmarks/benchmark.hs
@@ -18,7 +18,7 @@ import           Data.Sequences.Lazy
 import qualified Data.Text as T
 import           Prelude
 
-maximumC :: (Monad m, Ord a) => Consumer a m (Maybe a)
+maximumC :: (Monad m, Ord a) => ConduitT a o m (Maybe a)
 maximumC =
     await >>= maybe (return Nothing) loop
   where
@@ -27,13 +27,13 @@ maximumC =
 
 allC :: Monad m
      => (a -> Bool)
-     -> Consumer a m Bool
+     -> ConduitT a o m Bool
 allC f = fmap isNothing $ C.find (Prelude.not . f)
 {-# INLINE allC #-}
 
 allOld :: Monad m
        => (a -> Bool)
-       -> Consumer a m Bool
+       -> ConduitT a o m Bool
 allOld f =
     loop
   where
@@ -60,14 +60,14 @@ foldMaybeNull f macc mono =
 foldC :: Monad m
       => (b -> a -> b)
       -> b
-      -> Consumer a m b
+      -> ConduitT a o m b
 foldC f =
     loop
   where
     loop !accum = await >>= maybe (return accum) (loop . f accum)
 {-# INLINE foldC #-}
 
-maximumEOld :: (Monad m, Seq.OrdSequence seq) => Consumer seq m (Maybe (Element seq))
+maximumEOld :: (Monad m, Seq.OrdSequence seq) => ConduitT seq o m (Maybe (Element seq))
 maximumEOld =
     start
   where

--- a/conduit/benchmarks/fusion.hs
+++ b/conduit/benchmarks/fusion.hs
@@ -10,11 +10,11 @@ import           Data.Monoid
 
 foldMapC :: (Monad m, Monoid b)
          => (a -> b)
-         -> Consumer a m b
+         -> ConduitT a o m b
 foldMapC f = let combiner accum = mappend accum . f in CL.fold combiner mempty
 {-# INLINE foldMapC #-}
 
-groupByC :: Monad m => (a -> a -> Bool) -> Conduit a m [a]
+groupByC :: Monad m => (a -> a -> Bool) -> ConduitT a [a] m ()
 groupByC f =
     start
   where

--- a/conduit/benchmarks/maximum.hs
+++ b/conduit/benchmarks/maximum.hs
@@ -25,14 +25,14 @@ std dev              18.15 ps   (13.74 ps .. 25.97 ps)
 -}
 
 -- Old definition
-maximum1 :: (Monad m, Ord a) => Consumer a m (Maybe a)
+maximum1 :: (Monad m, Ord a) => ConduitT a o m (Maybe a)
 maximum1 =
     await >>= maybe (return Nothing) loop
   where
     loop prev = await >>= maybe (return $ Just prev) (loop . max prev)
 {-# INLINE [0] maximum1 #-}
 
-maximum2 :: (Monad m, Ord a) => Consumer a m (Maybe a)
+maximum2 :: (Monad m, Ord a) => ConduitT a o m (Maybe a)
 maximum2 = C.foldl1 max
 {-# INLINE [0] maximum2 #-}
 

--- a/conduit/benchmarks/scanl-bench.hs
+++ b/conduit/benchmarks/scanl-bench.hs
@@ -8,7 +8,7 @@ import Data.Functor.Identity
 test name f =
     bench name $ flip nf 200 $ \i -> runIdentity (replicateM_ i (yield ()) $= f (\_ _ -> ((), Nothing)) () $= CL.catMaybes $$ CL.sinkNull)
 
-cScanl :: Monad m => (a -> s -> (s, b)) -> s -> Conduit a m b
+cScanl :: Monad m => (a -> s -> (s, b)) -> s -> ConduitT a b m ()
 cScanl step = loop where
     loop state =
         do ma <- await
@@ -16,7 +16,7 @@ cScanl step = loop where
              Nothing -> return ()
              Just a -> let ~(newState, b) = step a state in yield b >> loop newState
 
-scanlOrig :: Monad m => (a -> s -> (s,b)) -> s -> Conduit a m b
+scanlOrig :: Monad m => (a -> s -> (s,b)) -> s -> ConduitT a b m ()
 scanlOrig f =
     loop
   where
@@ -25,7 +25,7 @@ scanlOrig f =
         go a = case f a s of
                  (s',b) -> yield b >> loop s'
 
-scanlOrigTweaked :: Monad m => (a -> s -> (s,b)) -> s -> Conduit a m b
+scanlOrigTweaked :: Monad m => (a -> s -> (s,b)) -> s -> ConduitT a b m ()
 scanlOrigTweaked f =
     loop
   where

--- a/conduit/benchmarks/utf8-bench.hs
+++ b/conduit/benchmarks/utf8-bench.hs
@@ -12,7 +12,7 @@ import qualified Data.Conduit.List as CL
 import Data.Text.StreamDecoding
 import Data.Text.Encoding (decodeUtf8)
 
-lengthT :: Monad m => Consumer T.Text m Int
+lengthT :: Monad m => ConduitT T.Text o m Int
 lengthT = CL.fold (\x y -> x + T.length y) 0
 
 main :: IO ()

--- a/conduit/src/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/src/Data/Conduit/Internal/Conduit.hs
@@ -327,7 +327,7 @@ connectResume (SealedConduitT left0) (ConduitT right0) =
       where
         recurse = goLeft rp rc
 
-sourceToPipe :: Monad m => Source m o -> Pipe l i o u m ()
+sourceToPipe :: Monad m => ConduitT () o m () -> Pipe l i o u m ()
 sourceToPipe (ConduitT k) =
     go $ k Done
   where
@@ -337,7 +337,7 @@ sourceToPipe (ConduitT k) =
     go (PipeM mp) = PipeM (liftM go mp)
     go (Leftover p ()) = go p
 
-sinkToPipe :: Monad m => Sink i m r -> Pipe l i o u m r
+sinkToPipe :: Monad m => ConduitT i Void m r -> Pipe l i o u m r
 sinkToPipe (ConduitT k) =
     go $ injectLeftovers $ k Done
   where
@@ -347,7 +347,7 @@ sinkToPipe (ConduitT k) =
     go (PipeM mp) = PipeM (liftM go mp)
     go (Leftover _ l) = absurd l
 
-conduitToPipe :: Monad m => Conduit i m o -> Pipe l i o u m ()
+conduitToPipe :: Monad m => ConduitT i o m () -> Pipe l i o u m ()
 conduitToPipe (ConduitT k) =
     go $ injectLeftovers $ k Done
   where
@@ -360,7 +360,7 @@ conduitToPipe (ConduitT k) =
 -- | Generalize a 'Source' to a 'Producer'.
 --
 -- Since 1.0.0
-toProducer :: Monad m => Source m a -> ConduitT i a m ()
+toProducer :: Monad m => ConduitT () a m () -> ConduitT i a m ()
 toProducer (ConduitT c0) = ConduitT $ \rest -> let
     go (HaveOutput p o) = HaveOutput (go p) o
     go (NeedInput _ c) = go (c ())
@@ -372,7 +372,7 @@ toProducer (ConduitT c0) = ConduitT $ \rest -> let
 -- | Generalize a 'Sink' to a 'Consumer'.
 --
 -- Since 1.0.0
-toConsumer :: Monad m => Sink a m b -> Consumer a m b
+toConsumer :: Monad m => ConduitT a Void m b -> ConduitT a o m b
 toConsumer (ConduitT c0) = ConduitT $ \rest -> let
     go (HaveOutput _ o) = absurd o
     go (NeedInput p c) = NeedInput (go . p) (go . c)
@@ -436,7 +436,7 @@ tryC c = fmap Right c `catchC` (return . Left)
 -- Any leftovers are discarded.
 --
 -- Since 0.4.1
-zipSinks :: Monad m => Sink i m r -> Sink i m r' -> Sink i m (r, r')
+zipSinks :: Monad m => ConduitT i Void m r -> ConduitT i Void m r' -> ConduitT i Void m (r, r')
 zipSinks (ConduitT x0) (ConduitT y0) = ConduitT $ \rest -> let
     Leftover _  i    >< _                = absurd i
     _                >< Leftover _  i    = absurd i
@@ -455,7 +455,7 @@ zipSinks (ConduitT x0) (ConduitT y0) = ConduitT $ \rest -> let
 --   source has been exhausted.
 --
 -- Since 1.0.13
-zipSources :: Monad m => Source m a -> Source m b -> Source m (a, b)
+zipSources :: Monad m => ConduitT () a m () -> ConduitT () b m () -> ConduitT () (a, b) m ()
 zipSources (ConduitT left0) (ConduitT right0) = ConduitT $ \rest -> let
     go (Leftover left ()) right = go left right
     go left (Leftover right ())  = go left right
@@ -476,7 +476,7 @@ zipSources (ConduitT left0) (ConduitT right0) = ConduitT $ \rest -> let
 --   source has been exhausted.
 --
 -- Since 1.0.13
-zipSourcesApp :: Monad m => Source m (a -> b) -> Source m a -> Source m b
+zipSourcesApp :: Monad m => ConduitT () (a -> b) m () -> ConduitT () a m () -> ConduitT () b m ()
 zipSourcesApp (ConduitT left0) (ConduitT right0) = ConduitT $ \rest -> let
     go (Leftover left ()) right = go left right
     go left (Leftover right ())  = go left right
@@ -601,11 +601,11 @@ connectResumeConduit (SealedConduitT left0) (ConduitT right0) = ConduitT $ \rest
 -- The new conduit will stop processing once either source or upstream have been exhausted.
 mergeSource
   :: Monad m
-  => Source m i
-  -> Conduit a m (i, a)
+  => ConduitT () i m ()
+  -> ConduitT a (i, a) m ()
 mergeSource = loop . sealConduitT
   where
-    loop :: Monad m => SealedConduitT () i m () -> Conduit a m (i, a)
+    loop :: Monad m => SealedConduitT () i m () -> ConduitT a (i, a) m ()
     loop src0 = await >>= maybe (return ()) go
       where
         go a = do
@@ -629,9 +629,9 @@ mergeSource = loop . sealConduitT
 --
 -- Since 1.1.0
 passthroughSink :: Monad m
-                => Sink i m r
+                => ConduitT i Void m r
                 -> (r -> m ()) -- ^ finalizer
-                -> Conduit i m i
+                -> ConduitT i i m ()
 passthroughSink (ConduitT sink0) final = ConduitT $ \rest -> let
     -- A bit of explanation is in order, this function is
     -- non-obvious. The purpose of go is to keep track of the sink
@@ -693,7 +693,7 @@ passthroughSink (ConduitT sink0) final = ConduitT $ \rest -> let
 -- underlying monad.
 --
 -- Since 1.2.6
-sourceToList :: Monad m => Source m a -> m [a]
+sourceToList :: Monad m => ConduitT () a m () -> m [a]
 sourceToList (ConduitT k) =
     go $ k Done
   where
@@ -763,7 +763,7 @@ unconsEitherM (SealedConduitT p) = go p
 -- deprecated and will be removed in a future version.
 --
 -- Since 1.2.3
-fuse :: Monad m => Conduit a m b -> ConduitM b c m r -> ConduitM a c m r
+fuse :: Monad m => ConduitT a b m () -> ConduitT b c m r -> ConduitT a c m r
 fuse = (=$=)
 
 -- | Combine two @Conduit@s together into a new @Conduit@ (aka 'fuse').
@@ -794,9 +794,9 @@ fuse = (=$=)
 --
 -- @since 1.2.8
 (.|) :: Monad m
-     => ConduitM a b m () -- ^ upstream
-     -> ConduitM b c m r -- ^ downstream
-     -> ConduitM a c m r
+     => ConduitT a b m () -- ^ upstream
+     -> ConduitT b c m r -- ^ downstream
+     -> ConduitT a c m r
 (.|) = fuse
 {-# INLINE (.|) #-}
 
@@ -864,7 +864,7 @@ ConduitT left0 =$= ConduitT right0 = ConduitT $ \rest ->
 -- also return @Nothing@.
 --
 -- Since 0.5.0
-await :: Monad m => Consumer i m (Maybe i)
+await :: Monad m => ConduitT i o m (Maybe i)
 await = ConduitT $ \f -> NeedInput (f . Just) (const $ f Nothing)
 {-# INLINE [0] await #-}
 
@@ -1051,14 +1051,14 @@ mapInputM f f' (ConduitT c0) = ConduitT $ \rest -> let
 -- Mnemonic: connect + do more.
 --
 -- Since 0.5.0
-($$+) :: Monad m => Source m a -> Sink a m b -> m (SealedConduitT () a m (), b)
+($$+) :: Monad m => ConduitT () a m () -> ConduitT a Void m b -> m (SealedConduitT () a m (), b)
 src $$+ sink = connectResume (sealConduitT src) sink
 {-# INLINE ($$+) #-}
 
 -- | Continue processing after usage of @$$+@.
 --
 -- Since 0.5.0
-($$++) :: Monad m => SealedConduitT () a m () -> Sink a m b -> m (SealedConduitT () a m (), b)
+($$++) :: Monad m => SealedConduitT () a m () -> ConduitT a Void m b -> m (SealedConduitT () a m (), b)
 ($$++) = connectResume
 {-# INLINE ($$++) #-}
 
@@ -1069,7 +1069,7 @@ src $$+ sink = connectResume (sealConduitT src) sink
 -- run. Since version 1.3.0, there are no finalizers in conduit.
 --
 -- Since 0.5.0
-($$+-) :: Monad m => SealedConduitT () a m () -> Sink a m b -> m b
+($$+-) :: Monad m => SealedConduitT () a m () -> ConduitT a Void m b -> m b
 rsrc $$+- sink = do
     (_, res) <- connectResume rsrc sink
     return res
@@ -1078,7 +1078,7 @@ rsrc $$+- sink = do
 -- | Left fusion for a sealed source.
 --
 -- Since 1.0.16
-($=+) :: Monad m => SealedConduitT () a m () -> Conduit a m b -> SealedConduitT () b m ()
+($=+) :: Monad m => SealedConduitT () a m () -> ConduitT a b m () -> SealedConduitT () b m ()
 SealedConduitT src $=+ ConduitT sink = SealedConduitT (src `pipeL` sink Done)
 
 -- | Provide for a stream of data that can be flushed.
@@ -1100,7 +1100,7 @@ instance Functor Flush where
 -- producing output.
 --
 -- Since 1.0.13
-newtype ZipSource m o = ZipSource { getZipSource :: Source m o }
+newtype ZipSource m o = ZipSource { getZipSource :: ConduitT () o m () }
 
 instance Monad m => Functor (ZipSource m) where
     fmap f = ZipSource . mapOutput f . getZipSource
@@ -1116,7 +1116,7 @@ instance Monad m => Applicative (ZipSource m) where
 -- multiple sources, use `sequence_`.
 --
 -- Since 1.0.13
-sequenceSources :: (Traversable f, Monad m) => f (Source m o) -> Source m (f o)
+sequenceSources :: (Traversable f, Monad m) => f (ConduitT () o m ()) -> ConduitT () (f o) m ()
 sequenceSources = getZipSource . sequenceA . fmap ZipSource
 
 -- | A wrapper for defining an 'Applicative' instance for 'Sink's which allows
@@ -1126,7 +1126,7 @@ sequenceSources = getZipSource . sequenceA . fmap ZipSource
 --
 -- @
 -- sequenceSinks :: (Monad m)
---           => [Sink i m r] -> Sink i m [r]
+--           => [ConduitT i Void m r] -> ConduitT i Void m [r]
 -- sequenceSinks = getZipSink . sequenceA . fmap ZipSink
 -- @
 --
@@ -1141,7 +1141,7 @@ sequenceSources = getZipSource . sequenceA . fmap ZipSource
 -- understood).
 --
 -- Since 1.0.13
-newtype ZipSink i m r = ZipSink { getZipSink :: Sink i m r }
+newtype ZipSink i m r = ZipSink { getZipSink :: ConduitT i Void m r }
 
 instance Monad m => Functor (ZipSink i m) where
     fmap f (ZipSink x) = ZipSink (liftM f x)
@@ -1156,7 +1156,7 @@ instance Monad m => Applicative (ZipSink i m) where
 -- Implemented on top of @ZipSink@, see that data type for more details.
 --
 -- Since 1.0.13
-sequenceSinks :: (Traversable f, Monad m) => f (Sink i m r) -> Sink i m (f r)
+sequenceSinks :: (Traversable f, Monad m) => f (ConduitT i Void m r) -> ConduitT i Void m (f r)
 sequenceSinks = getZipSink . sequenceA . fmap ZipSink
 
 -- | The connect-and-resume operator. This does not close the @Conduit@, but
@@ -1282,7 +1282,7 @@ fuseBothMaybe (ConduitT up) (ConduitT down) =
 -- @Conduit@. Same caveats of forced consumption apply.
 --
 -- Since 1.1.5
-fuseUpstream :: Monad m => ConduitT a b m r -> Conduit b m c -> ConduitT a c m r
+fuseUpstream :: Monad m => ConduitT a b m r -> ConduitT b c m () -> ConduitT a c m r
 fuseUpstream up down = fmap fst (fuseBoth up down)
 {-# INLINE fuseUpstream #-}
 

--- a/conduit/src/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/src/Data/Conduit/Internal/Conduit.hs
@@ -689,7 +689,7 @@ passthroughSink (ConduitT sink0) final = ConduitT $ \rest -> let
 -- However, @sourceToList@ is able to produce its results lazily, which cannot
 -- be done when running a conduit pipeline in general. Unlike the
 -- @Data.Conduit.Lazy@ module (in conduit-extra), this function performs no
--- unsafe I\/O operations, and therefore can only be as lazily as the
+-- unsafe I\/O operations, and therefore can only be as lazy as the
 -- underlying monad.
 --
 -- Since 1.2.6

--- a/conduit/src/Data/Conduit/List.hs
+++ b/conduit/src/Data/Conduit/List.hs
@@ -463,7 +463,7 @@ STREAMING(map, mapC, mapS, f)
 {-
 {-# RULES "conduit: source/map fusion .|" forall f src. src .| map f = mapFuseRight src f #-}
 
-mapFuseRight :: Monad m => Source m a -> (a -> b) -> Source m b
+mapFuseRight :: Monad m => ConduitT () a m () -> (a -> b) -> ConduitT () b m ()
 mapFuseRight src f = CIC.mapOutput f src
 {-# INLINE mapFuseRight #-}
 -}


### PR DESCRIPTION
This inlines uses of the deprcated type aliases `Source`, `Sink`, `Producer`, `Consumer`, `Conduit` in the documentation and type annotations so that they now use the recommended `ConduitT` type instead.