### PR TITLE
*> leaks space where >> doesn't

### DIFF
--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for conduit
 
+## 1.3.4.3
+
+* Fix space leak in `*>` [#496](https://github.com/snoyberg/conduit/issues/496) [#497](https://github.com/snoyberg/conduit/pull/497)
+
 ## 1.3.4.2
 
 * Fix GHC 9.2 build [#473](https://github.com/snoyberg/conduit/pull/473)

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -1,5 +1,5 @@
 Name:                conduit
-Version:             1.3.4.2
+Version:             1.3.4.3
 Synopsis:            Streaming data processing library.
 description:
     `conduit` is a solution to the streaming data problem, allowing for production,

--- a/conduit/src/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/src/Data/Conduit/Internal/Conduit.hs
@@ -148,6 +148,8 @@ instance Applicative (ConduitT i o m) where
     {-# INLINE pure #-}
     (<*>) = ap
     {-# INLINE (<*>) #-}
+    (*>) = (>>)
+    {-# INLINE (*>) #-}
 
 instance Monad (ConduitT i o m) where
     return = pure


### PR DESCRIPTION
So just implemented *> in terms of >>. Resolves https://github.com/snoyberg/conduit/issues/496.