### PR TITLE
add missing MonadCatch instance

### DIFF
--- a/conduit/src/Conduit.hs
+++ b/conduit/src/Conduit.hs
@@ -20,6 +20,7 @@ module Conduit
     , MonadIO (..)
     , MonadTrans (..)
     , MonadThrow (..)
+    , MonadCatch (..)
     , MonadUnliftIO (..)
     , PrimMonad (..)
       -- * ResourceT
@@ -39,5 +40,5 @@ import Control.Monad.Primitive (PrimMonad (..), PrimState)
 import Data.Conduit.Lift
 import Data.Conduit.Combinators.Unqualified
 import Data.Functor.Identity (Identity (..))
-import Control.Monad.Trans.Resource (MonadResource, MonadThrow (..), runResourceT, ResourceT)
+import Control.Monad.Trans.Resource (MonadResource, MonadThrow (..), MonadCatch (..), runResourceT, ResourceT)
 import Data.Acquire hiding (with)

--- a/resourcet/Control/Monad/Trans/Resource.hs
+++ b/resourcet/Control/Monad/Trans/Resource.hs
@@ -54,6 +54,7 @@ module Control.Monad.Trans.Resource
     , closeInternalState
       -- * Reexport
     , MonadThrow (..)
+    , MonadCatch (..)
     ) where
 
 import qualified Data.IntMap as IntMap
@@ -65,7 +66,7 @@ import Control.Monad.Trans.Resource.Internal
 
 import Control.Concurrent (ThreadId, forkIO)
 
-import Control.Monad.Catch (MonadThrow, throwM)
+import Control.Monad.Catch (MonadThrow (..), MonadCatch (..))
 import Data.Acquire.Internal (ReleaseType (..))
 
 


### PR DESCRIPTION
`ConduitT` implements `MonadError` for a generic error type, which is in principle equivalent to `MonadCatch`.

Tested this together with @vkleen on https://github.com/ners/dosh