### PR TITLE
Avoid Dropping Upstream Items in `mergeSource`

### DIFF
--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for conduit
 
+## 1.3.6
+
+* Avoid dropping upstream items in `mergeSource` [#513](https://github.com/snoyberg/conduit/pull/513)
+
 ## 1.3.5
 
 * Add `groupOn`

--- a/conduit/src/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/src/Data/Conduit/Internal/Conduit.hs
@@ -613,7 +613,7 @@ mergeSource = loop . sealConduitT
         go a = do
           (src1, mi) <- lift $ src0 $$++ await
           case mi of
-            Nothing -> return ()
+            Nothing -> leftover a
             Just i  -> yield (i, a) >> loop src1
 
 

--- a/conduit/test/main.hs
+++ b/conduit/test/main.hs
@@ -704,6 +704,12 @@ main = hspec $ do
                 withShortAlphaIndex = CI.mergeSource (CL.sourceList ["A", "B", "C"])
             output <- runConduit $ src .| withShortAlphaIndex .| CL.consume
             output `shouldBe` [("A", 1), ("B", 2), ("C", 3)]
+        it "does not drop upstream items" $ do
+            let num = CL.sourceList [1 .. 10 :: Int]
+            let chr = CL.sourceList ['a' .. 'c']
+            (output, remainder) <- runConduit $ num .| liftA2 (,) (CI.mergeSource chr .| CL.consume) CL.consume
+            output `shouldBe` [('a', 1), ('b', 2), ('c', 3)]
+            remainder `shouldBe` [4 .. 10]
 
     describe "passthroughSink" $ do
         it "works" $ do

--- a/conduit/test/main.hs
+++ b/conduit/test/main.hs
@@ -32,7 +32,7 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Writer (execWriter, tell, runWriterT)
 import Control.Monad.Trans.State (evalStateT, get, put)
 import qualified Control.Monad.Writer as W
-import Control.Applicative (pure, (<$>), (<*>))
+import Control.Applicative (pure, (<$>), (<*>), liftA2)
 import qualified Control.Monad.Catch as Catch
 import Data.Functor.Identity (Identity,runIdentity)
 import Control.Monad (forever, void)


### PR DESCRIPTION
From what I understand, `mergeSource` will `await` an item from upstream, and if successful, `await` an item from `src0`. If there is no item in `src0`, the conduit terminates. This means that the item that was already taken from upstream is now lost (note the missing item `4` in the output):
```hs
>>> let num = C.yieldMany [1 .. 10]
>>> let chr = C.yieldMany ['a' .. 'c']
>>> runConduitPure $ num .| liftA2 (,) (mergeSource chr .| C.sinkList) C.sinkList
([('a',1),('b',2),('c',3)],[5,6,7,8,9,10])
```

This PR adds the already consumed item back using `leftover`, leading to the expected result:
```hs
([('a',1),('b',2),('c',3)],[4,5,6,7,8,9,10])
```

Disclaimer: I am pretty new to Conduit, so it is possible that I am either misunderstanding something or that there is a good reason for the current behavior of `mergeSource`, in which case, feel free to correct me.