### PR TITLE
Allow Data.Conduit.Network.Unix on Windows

### DIFF
--- a/conduit-extra/ChangeLog.md
+++ b/conduit-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for conduit-extra
 
+## 1.3.7
+
+* Allow Data.Conduit.Network.Unix on Windows [#518](https://github.com/snoyberg/conduit/pull/518)
+
 ## 1.3.6
 
 * Add support for `transformers-0.6`

--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -1,6 +1,6 @@
 Cabal-version:       >=1.10
 Name:                conduit-extra
-Version:             1.3.6
+Version:             1.3.7
 Synopsis:            Batteries included conduit: adapters for common libraries.
 Description:
     The conduit package itself maintains relative small dependencies. The purpose of this package is to collect commonly used utility functions wrapping other library dependencies, without depending on heavier-weight dependencies. The basic idea is that this package should only depend on haskell-platform packages and conduit.
@@ -28,12 +28,11 @@ Library
                        Data.Conduit.Lazy
                        Data.Conduit.Network
                        Data.Conduit.Network.UDP
+                       Data.Conduit.Network.Unix
                        Data.Conduit.Process
                        Data.Conduit.Process.Typed
                        Data.Conduit.Text
                        Data.Conduit.Zlib
-  if !os(windows)
-      Exposed-modules: Data.Conduit.Network.Unix
 
   if arch(x86_64) || arch(i386)
       -- These architectures are able to perform unaligned memory accesses
@@ -55,7 +54,7 @@ Library
                      , process
                      , resourcet                >= 1.1
                      , stm
-                     , streaming-commons        >= 0.1.16
+                     , streaming-commons        >= 0.2.3.0
                      , unliftio-core
                      , typed-process            >= 0.2.6
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,6 +14,7 @@ extra-deps:
 - crypton-x509-store-1.6.9
 - crypton-x509-system-1.6.7
 - crypton-x509-validation-1.6.12
+- streaming-commons-0.2.3.0
 - tls-1.7.0
 drop-packages:
 - cryptonite

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -47,6 +47,13 @@ packages:
   original:
     hackage: crypton-x509-validation-1.6.12
 - completed:
+    hackage: streaming-commons-0.2.3.0@sha256:68d5f3daa6caa7cc7d659094a03d543021df5ec4737b67e63ffa4541ac0aae10,4841
+    pantry-tree:
+      sha256: 66a00daed951de5a26118dac7e34c72ee32f33ddcd3a50981d80b4dd244992b4
+      size: 2374
+  original:
+    hackage: streaming-commons-0.2.3.0
+- completed:
     hackage: tls-1.7.0@sha256:fa82e9ca8fd887b66fba8433b3ba1db4e5e047fe7c815707f06209679d04177b,5566
     pantry-tree:
       sha256: 7521091021ecbbbf9b46c2fdb08f9e449eddcebf3a3922f76d23baca5db83b4f


### PR DESCRIPTION
Hello, this is a follow-up from https://github.com/fpco/streaming-commons/pull/80 to expose the new functionality in `conduit-extra` for Windows.

I bumped the bound on `streaming-commons` to `0.2.3.0` and bumped the minor version number of `conduit-extra`. If that's too disruptive, we could potentially raise the bound for Windows only and leave it as-is for other platforms.

CC @snoyberg 