### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/conduit/ChangeLog.md
+++ b/conduit/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for conduit
 
+## 1.3.6.1
+
+* Forward compatibility with `-Wnoncanonical-monad-instances` becoming an error
+
 ## 1.3.6
 
 * Avoid dropping upstream items in `mergeSource` [#513](https://github.com/snoyberg/conduit/pull/513)

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -1,5 +1,5 @@
 Name:                conduit
-Version:             1.3.6
+Version:             1.3.6.1
 Synopsis:            Streaming data processing library.
 description:
     `conduit` is a solution to the streaming data problem, allowing for production,

--- a/conduit/src/Data/Conduit/Internal/Conduit.hs
+++ b/conduit/src/Data/Conduit/Internal/Conduit.hs
@@ -148,7 +148,7 @@ instance Applicative (ConduitT i o m) where
     {-# INLINE pure #-}
     (<*>) = ap
     {-# INLINE (<*>) #-}
-    (*>) = (>>)
+    x *> y = x >>= \_ -> y
     {-# INLINE (*>) #-}
 
 instance Monad (ConduitT i o m) where


### PR DESCRIPTION
This appeases the -Wnoncanonical-monad-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return

(Special note: ordinarily, the remedy here would be to remove the `(*>) = (>>)` definition. But snoyberg/conduit#497 indicates that this would cause a performance regression, so instead I have inlined `(>>)`. The important thing is that, if `(>>)` is later defined to equal `(*>)`, this doesn't result in a loop.)