### PR TITLE
Base 4.14

### DIFF
--- a/conduit-extra/ChangeLog.md
+++ b/conduit-extra/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for conduit-extra
 
+## Unreleased (patch)
+
+* Correctly set `base` lower bound to `>= 4.14` (GHC 8.10)
+
 ## 1.3.8
 
 * Gracefully handle when a subprocess started using `Data.Conduit.Process.sourceProcessWithStreams` closes its stdin. Fixes [#523](https://github.com/snoyberg/conduit/issues/523)

--- a/conduit-extra/ChangeLog.md
+++ b/conduit-extra/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased (patch)
 
+* Removed CPP for GHC <7.10
 * Correctly set `base` lower bound to `>= 4.14` (GHC 8.10)
 
 ## 1.3.8

--- a/conduit-extra/Data/Conduit/Binary.hs
+++ b/conduit-extra/Data/Conduit/Binary.hs
@@ -73,9 +73,6 @@ import Control.Monad.Trans.Resource (allocate, release, MonadThrow (..))
 import Control.Monad.Trans.Class (lift)
 import qualified System.IO as IO
 import Data.Word (Word8, Word64)
-#if (__GLASGOW_HASKELL__ < 710)
-import Control.Applicative ((<$>))
-#endif
 import System.Directory (getTemporaryDirectory, removeFile)
 import Data.ByteString.Lazy.Internal (defaultChunkSize)
 import Data.ByteString.Internal (ByteString (PS), accursedUnutterablePerformIO)

--- a/conduit-extra/Data/Conduit/Lazy.hs
+++ b/conduit-extra/Data/Conduit/Lazy.hs
@@ -35,9 +35,6 @@ import qualified Control.Monad.Trans.RWS.Strict    as Strict ( RWST   )
 import qualified Control.Monad.Trans.State.Strict  as Strict ( StateT )
 import qualified Control.Monad.Trans.Writer.Strict as Strict ( WriterT )
 
-#if (__GLASGOW_HASKELL__ < 710)
-import Data.Monoid (Monoid)
-#endif
 import Control.Monad.ST (ST)
 import qualified Control.Monad.ST.Lazy as Lazy
 import Data.Functor.Identity (Identity)

--- a/conduit-extra/Data/Conduit/Process.hs
+++ b/conduit-extra/Data/Conduit/Process.hs
@@ -41,9 +41,6 @@ import Data.ByteString.Builder (Builder)
 import Control.Concurrent.Async (runConcurrently, Concurrently(..))
 import Control.Exception (onException, throwIO, finally, bracket, catch)
 import System.IO.Error (ioeGetErrorType, isResourceVanishedErrorType)
-#if (__GLASGOW_HASKELL__ < 710)
-import Control.Applicative ((<$>), (<*>))
-#endif
 
 instance (r ~ (), MonadIO m, i ~ ByteString) => InputSource (ConduitM i o m r) where
     isStdStream = (\(Just h) -> hSetBuffering h NoBuffering $> sinkHandle h, Just CreatePipe)

--- a/conduit-extra/conduit-extra.cabal
+++ b/conduit-extra/conduit-extra.cabal
@@ -38,7 +38,7 @@ Library
       -- These architectures are able to perform unaligned memory accesses
       cpp-options: -DALLOW_UNALIGNED_ACCESS
 
-  Build-depends:       base                     >= 4.12         && < 5
+  Build-depends:       base                     >= 4.14         && < 5
                      , conduit                  >= 1.3          && < 1.4
 
                      , bytestring               >= 0.10.2

--- a/conduit/src/System/Win32File.hsc
+++ b/conduit/src/System/Win32File.hsc
@@ -11,11 +11,7 @@ import Foreign.C.String (CString)
 import Foreign.Ptr (castPtr)
 import Foreign.Marshal.Alloc (mallocBytes, free)
 import Foreign.ForeignPtr       (ForeignPtr, withForeignPtr)
-#if __GLASGOW_HASKELL__ >= 704
 import Foreign.C.Types (CInt (..))
-#else
-import Foreign.C.Types (CInt)
-#endif
 import Foreign.C.Error (throwErrnoIfMinus1Retry)
 import Foreign.Ptr (Ptr)
 import Data.Bits (Bits, (.|.))

--- a/resourcet/Control/Monad/Trans/Resource/Internal.hs
+++ b/resourcet/Control/Monad/Trans/Resource/Internal.hs
@@ -180,23 +180,7 @@ transResourceT f (ResourceT mx) = ResourceT (\r -> f (mx r))
 --
 -- Since 0.3.0
 newtype ResourceT m a = ResourceT { unResourceT :: I.IORef ReleaseMap -> m a }
-#if __GLASGOW_HASKELL__ >= 707
         deriving Typeable
-#else
-instance Typeable1 m => Typeable1 (ResourceT m) where
-    typeOf1 = goType undefined
-      where
-        goType :: Typeable1 m => m a -> ResourceT m a -> TypeRep
-        goType m _ =
-            mkTyConApp
-#if __GLASGOW_HASKELL__ >= 704
-                (mkTyCon3 "resourcet" "Control.Monad.Trans.Resource" "ResourceT")
-#else
-                (mkTyCon "Control.Monad.Trans.Resource.ResourceT")
-#endif
-                [ typeOf1 m
-                ]
-#endif
 
 -- | Indicates either an error in the library, or misuse of it (e.g., a
 -- @ResourceT@'s state is accessed after being released).


### PR DESCRIPTION
Closes #525

Can we please have a metadata revision for `base >= 4.14` against `conduit-extra-1.3.8`?