### PR TITLE
Make use of dirEntType in sourceDirectoryDeep

### DIFF
--- a/conduit/benchmarks/source-directory.hs
+++ b/conduit/benchmarks/source-directory.hs
@@ -1,0 +1,16 @@
+import Conduit
+import System.Directory (getHomeDirectory)
+import Test.Tasty.Bench
+
+main :: IO ()
+main = defaultMain
+  [ env getHomeDirectory $ \home ->
+    let benchSourceDir followSymlinks = bench ("..." ++ show followSymlinks) $
+            nfIO $ runConduitRes $
+                sourceDirectoryDeep followSymlinks home
+                .| sinkNull
+    in bgroup "sourceDirectoryDeep..."
+      [ benchSourceDir False
+      , benchSourceDir True
+      ]
+  ]

--- a/conduit/conduit.cabal
+++ b/conduit/conduit.cabal
@@ -131,9 +131,20 @@ benchmark optimize-201408
                   , transformers
                   , hspec
                   , mwc-random
-                  , gauge
+                  , tasty-bench
     main-is:        optimize-201408.hs
     ghc-options:    -Wall -O2 -rtsopts
+
+benchmark source-directory
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    hs-source-dirs:   benchmarks
+    build-depends:    base
+                    , conduit
+                    , directory
+                    , tasty-bench
+    main-is:          source-directory.hs
+    ghc-options:      -Wall -O2 -rtsopts
 
 benchmark unfused
     default-language:    Haskell2010
@@ -141,7 +152,7 @@ benchmark unfused
     hs-source-dirs: benchmarks
     build-depends:  base
                   , conduit
-                  , gauge
+                  , tasty-bench
                   , transformers
     main-is:        unfused.hs
     ghc-options:    -Wall -O2 -rtsopts

--- a/conduit/src/Data/Conduit/Combinators.hs
+++ b/conduit/src/Data/Conduit/Combinators.hs
@@ -233,12 +233,12 @@ import           Prelude                     (Bool (..), Eq (..), Int,
                                               Maybe (..), Either (..), Monad (..), Num (..),
                                               Ord (..), fromIntegral, maybe, either,
                                               ($), Functor (..), Enum, seq, Show, Char,
-                                              otherwise, Either (..), not,
+                                              otherwise, Either (..), not, fst,
                                               ($!), succ, FilePath, IO, String)
 import Data.Word (Word8)
 import qualified Prelude
 import qualified System.IO                   as IO
-import           System.IO.Error             (isDoesNotExistError)
+import           System.IO.Error             (IOError, isDoesNotExistError)
 import           System.IO.Unsafe            (unsafePerformIO)
 import Data.ByteString (ByteString)
 import Data.Text (Text)
@@ -702,17 +702,23 @@ withSinkFileBuilder fp inner =
 -- @since 1.3.0
 sourceDirectory :: MonadResource m => FilePath -> ConduitT i FilePath m ()
 sourceDirectory dir =
+    sourceDirectoryTyped dir .| map fst
+
+sourceDirectoryTyped :: MonadResource m
+                     => FilePath
+                     -> ConduitT i (FilePath, Maybe F.FileType) m ()
+sourceDirectoryTyped dir =
     bracketP (F.openDirStream dir) F.closeDirStream go
   where
     go ds =
         loop
       where
         loop = do
-            mfp <- liftIO $ F.readDirStream ds
-            case mfp of
+            mfpmft <- liftIO $ F.readDirStreamTyped ds
+            case mfpmft of
                 Nothing -> return ()
-                Just fp -> do
-                    yield $ dir </> fp
+                Just (fp, mft) -> do
+                    yield (dir </> fp, mft)
                     loop
 
 -- | Deeply stream the contents of the given directory.
@@ -730,19 +736,17 @@ sourceDirectoryDeep followSymlinks =
     start
   where
     start :: MonadResource m => FilePath -> ConduitT i FilePath m ()
-    start dir = sourceDirectory dir .| awaitForever go
+    start dir = sourceDirectoryTyped dir .| awaitForever go
 
-    go :: MonadResource m => FilePath -> ConduitT i FilePath m ()
-    go fp = do
-        ft <- liftIO $ F.getFileType fp
-        case ft of
-            F.FTFile -> yield fp
-            F.FTFileSym -> yield fp
-            F.FTDirectory -> start fp
-            F.FTDirectorySym
-                | followSymlinks -> start fp
-                | otherwise -> return ()
-            F.FTOther -> return ()
+    go :: MonadResource m
+       => (FilePath, Maybe F.FileType)
+       -> ConduitT i FilePath m ()
+    go (fp, mft) = do
+        ftOrE <- liftIO $ try $ F.resolveFileType fp mft followSymlinks
+        case ftOrE :: Either IOError F.FileType of
+            Right F.FTFile      -> yield fp
+            Right F.FTDirectory -> start fp
+            _                   -> return ()
 
 -- | Ignore a certain number of values in the stream.
 --

--- a/conduit/src/Data/Streaming/Filesystem.hs
+++ b/conduit/src/Data/Streaming/Filesystem.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | Streaming functions for interacting with the filesystem.
 module Data.Streaming.Filesystem
     ( DirStream
     , openDirStream
-    , readDirStream
+    , readDirStreamTyped
     , closeDirStream
     , FileType (..)
-    , getFileType
+    , resolveFileType
     ) where
-
-import Data.Typeable (Typeable)
 
 #if WINDOWS
 
+import Data.Typeable (Typeable)
 import qualified System.Win32 as Win32
 import System.FilePath ((</>))
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
@@ -32,23 +32,20 @@ openDirStream fp = do
 closeDirStream :: DirStream -> IO ()
 closeDirStream (DirStream h _ _) = Win32.findClose h
 
-readDirStream :: DirStream -> IO (Maybe FilePath)
-readDirStream ds@(DirStream h fdat imore) = do
+readDirStreamTyped :: DirStream -> IO (Maybe (FilePath, Maybe FileType))
+readDirStreamTyped ds@(DirStream h fdat imore) = do
     more <- readIORef imore
     if more
         then do
             filename <- Win32.getFindDataFileName fdat
             Win32.findNextFile h fdat >>= writeIORef imore
             if filename == "." || filename == ".."
-                then readDirStream ds
-                else return $ Just filename
+                then readDirStreamTyped ds
+                else return $ Just (filename, Nothing)
         else return Nothing
 
-isSymlink :: FilePath -> IO Bool
-isSymlink _ = return False
-
-getFileType :: FilePath -> IO FileType
-getFileType fp = do
+resolveFileType :: FilePath -> Maybe FileType -> Bool -> IO FileType
+resolveFileType fp _ _ = do
     isFile <- doesFileExist fp
     if isFile
         then return FTFile
@@ -59,42 +56,58 @@ getFileType fp = do
 #else
 
 import System.Posix.Directory (DirStream, openDirStream, closeDirStream)
-import qualified System.Posix.Directory as Posix
+import qualified System.Posix.Directory.Internals as I
+import qualified System.Posix.Internals as I
 import qualified System.Posix.Files as PosixF
-import Control.Exception (try, IOException)
 
-readDirStream :: DirStream -> IO (Maybe FilePath)
-readDirStream ds = do
-    fp <- Posix.readDirStream ds
-    case fp of
-        "" -> return Nothing
-        "." -> readDirStream ds
-        ".." -> readDirStream ds
-        _ -> return $ Just fp
+peekFpAndType :: I.DirEnt -> IO (FilePath, Maybe FileType)
+peekFpAndType de = do
+    fp <- I.dirEntName de >>= I.peekFilePath
+    dt <- I.dirEntType de
+    return (fp, dTypeToFileType dt)
 
-getFileType :: FilePath -> IO FileType
-getFileType fp = do
-    s <- PosixF.getSymbolicLinkStatus fp
-    case () of
-        ()
-            | PosixF.isRegularFile s -> return FTFile
-            | PosixF.isDirectory s -> return FTDirectory
-            | PosixF.isSymbolicLink s -> do
-                es' <- try $ PosixF.getFileStatus fp
-                case es' of
-                    Left (_ :: IOException) -> return FTOther
-                    Right s'
-                        | PosixF.isRegularFile s' -> return FTFileSym
-                        | PosixF.isDirectory s' -> return FTDirectorySym
-                        | otherwise -> return FTOther
-            | otherwise -> return FTOther
+dTypeToFileType :: I.DirType -> Maybe FileType
+dTypeToFileType = \case
+    I.RegularFileType  -> Just FTFile
+    I.DirectoryType    -> Just FTDirectory
+    I.SymbolicLinkType -> Just FTSymlink
+    I.UnknownType      -> Nothing
+    _                  -> Just FTOther
+
+statToFileType :: PosixF.FileStatus -> FileType
+statToFileType s
+    | PosixF.isRegularFile s  = FTFile
+    | PosixF.isDirectory s    = FTDirectory
+    | PosixF.isSymbolicLink s = FTSymlink
+    | otherwise               = FTOther
+
+readDirStreamTyped :: DirStream -> IO (Maybe (FilePath, Maybe FileType))
+readDirStreamTyped ds = go where
+    go = I.readDirStreamWith peekFpAndType ds >>= \case
+        Just (".",  _) -> go
+        Just ("..", _) -> go
+        mfpmft         -> return mfpmft
+
+resolveFileType :: FilePath -> Maybe FileType -> Bool -> IO FileType
+resolveFileType fp mft followSymlinks =
+    let resolveUnknown Nothing = statToFileType <$> if followSymlinks
+            then PosixF.getFileStatus fp
+            else PosixF.getSymbolicLinkStatus fp
+        resolveUnknown (Just ft) = return ft
+
+        resolveSymlink FTSymlink = do
+            s <- PosixF.getFileStatus fp
+            return $ case statToFileType s of
+                FTDirectory | not followSymlinks -> FTSymlink
+                ft                               -> ft
+        resolveSymlink ft = return ft
+
+    in resolveUnknown mft >>= resolveSymlink
 
 #endif
 
 data FileType
     = FTFile
-    | FTFileSym -- ^ symlink to file
     | FTDirectory
-    | FTDirectorySym -- ^ symlink to a directory
+    | FTSymlink
     | FTOther
-    deriving (Show, Read, Eq, Ord, Typeable)

--- a/conduit/test/Spec.hs
+++ b/conduit/test/Spec.hs
@@ -6,7 +6,6 @@
 module Spec (spec) where
 
 import Conduit
-import Prelude hiding (FilePath)
 import Data.Maybe (listToMaybe)
 import Data.Conduit.Combinators (slidingWindow, chunksOfE, chunksOfExactlyE)
 import Data.List (intersperse, sort, find, mapAccumL)
@@ -42,7 +41,9 @@ import Data.ByteString.Builder (byteString, toLazyByteString)
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy.Char8 as L8
 import qualified StreamSpec
+import UnliftIO.Directory
 import UnliftIO.Exception (pureTry)
+import UnliftIO.Temporary (withTempDirectory)
 
 spec :: Spec
 spec = do
@@ -128,33 +129,49 @@ spec = do
             hDuplicateTo h IO.stdin
             x <- runConduit $ stdinC .| foldC
             x `shouldBe` content
-    let hasExtension' ext fp = takeExtension fp == ext
-    it "sourceDirectory" $ do
-        res <- runConduitRes
-             $ sourceDirectory "test" .| filterC (not . hasExtension' ".swp") .| sinkList
-        sort res `shouldBe`
-          [ "test" </> "Data"
-          , "test" </> "Spec.hs"
-          , "test" </> "StreamSpec.hs"
-          , "test" </> "doctests.hs"
-          , "test" </> "main.hs"
-          , "test" </> "subdir"
+    let testSourceDir :: (FilePath -> ConduitT () FilePath (ResourceT IO) ())
+                      -> [FilePath]
+                      -> Expectation
+        testSourceDir sourceDir expectedFiles =
+            withTempDirectory "." "conduit-test-" $ \tempDir ->
+                withCurrentDirectory tempDir $ do
+                    setupTestDir
+                    res <- runConduitRes $ sourceDir "." .| sinkList
+                    sort res `shouldBe` map ("." </>) (sort expectedFiles)
+        setupTestDir = do
+            writeFile "a-file.txt" ""
+            createDirectory "a-dir"
+            writeFile ("a-dir" </> "another-file.txt") ""
+#ifndef WINDOWS
+            createFileLink "a-file.txt" "a-link.txt"
+            createDirectoryLink "a-dir" "a-dir-link"
+#endif
+    it "sourceDirectory" $
+        testSourceDir sourceDirectory
+          [ "a-file.txt"
+          , "a-dir"
+#ifndef WINDOWS
+          , "a-link.txt"
+          , "a-dir-link"
+#endif
           ]
-    it "sourceDirectoryDeep" $ do
-        res1 <- runConduitRes
-              $ sourceDirectoryDeep False "test" .| filterC (not . hasExtension' ".swp") .| sinkList
-        res2 <- runConduitRes
-              $ sourceDirectoryDeep True "test" .| filterC (not . hasExtension' ".swp") .| sinkList
-        sort res1 `shouldBe`
-          [ "test" </> "Data" </> "Conduit" </> "Extra" </> "ZipConduitSpec.hs"
-          , "test" </> "Data" </> "Conduit" </> "StreamSpec.hs"
-          , "test" </> "Spec.hs"
-          , "test" </> "StreamSpec.hs"
-          , "test" </> "doctests.hs"
-          , "test" </> "main.hs"
-          , "test" </> "subdir" </> "dummyfile.txt"
+    it "sourceDirectoryDeep False" $
+        testSourceDir (sourceDirectoryDeep False)
+          [ "a-file.txt"
+          , "a-dir" </> "another-file.txt"
+#ifndef WINDOWS
+          , "a-link.txt"
+#endif
           ]
-        sort res1 `shouldBe` sort res2
+    it "sourceDirectoryDeep True" $
+        testSourceDir (sourceDirectoryDeep True)
+          [ "a-file.txt"
+          , "a-dir" </> "another-file.txt"
+#ifndef WINDOWS
+          , "a-link.txt"
+          , "a-dir-link" </> "another-file.txt"
+#endif
+          ]
     prop "drop" $ \(T.pack -> input) count ->
         runConduitPure (yieldMany input .| (dropC count >>= \() -> sinkList))
         `shouldBe` T.unpack (T.drop count input)


### PR DESCRIPTION
This is halfway towards #459.  The other half is getting `dirEntType` itself fixed in unix, which is currently hard-coded to return `UnknownType` and effectively reverts to the current behavior of `stat()`ing every file.  That fix is https://github.com/haskell/unix/pull/348.  They can be merged in any order.

Benchmarks running `sourceDirectoryDeep` into `sinkNull` from my home dir (about 500K files):

| | Follow symlinks? | Time |
| --- | --- | --- |
| Current | &cross; | 1.71s |
| Current | &check; | 3.19s |
| After this PR | &cross; | 1.70s |
| After this PR | &check; | 3.18s |
| After this and the unix PR | &cross; | 0.94s |
| After this and the unix PR | &check; | 1.96s |